### PR TITLE
Moving routes under '/api'.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val downgradedSprayV = "1.3.1"
 val akkaV = "2.3.12"
 val slickV = "3.1.0"
 
-val lenthallV = "0.13-eb2dd2d-SNAPSHOT"
+val lenthallV = "0.14-6479841-SNAPSHOT"
 
 resolvers ++= Seq(
   "Broad Artifactory Releases" at "https://artifactory.broadinstitute.org/artifactory/libs-release/",
@@ -45,7 +45,8 @@ libraryDependencies ++= Seq(
   "io.spray" %% "spray-testkit" % sprayV % Test,
   "org.scalatest" %% "scalatest" % "2.2.5" % Test,
   "com.typesafe.akka" %% "akka-testkit" % akkaV % Test,
-  "org.liquibase" % "liquibase-core" % "3.3.5" % Test
+  "org.liquibase" % "liquibase-core" % "3.3.5" % Test,
+  "org.yaml" % "snakeyaml" % "1.16" % Test
 )
 
 releaseSettings

--- a/src/main/resources/swagger/thurloe.yaml
+++ b/src/main/resources/swagger/thurloe.yaml
@@ -3,6 +3,7 @@ info:
   title: Thurloe
   description: All your key/value pairs are belong to us
   version: 0.2
+basePath: /api
 paths:
   /thurloe:
     post:

--- a/src/main/scala/thurloe/Main.scala
+++ b/src/main/scala/thurloe/Main.scala
@@ -11,9 +11,8 @@ object Main extends App {
   // We need an ActorSystem to host our application in
   implicit val system = ActorSystem("thurloe")
 
-  val swaggerService = SwaggerService.from(ConfigFactory.load())
   // create and start our service actor
-  val service = system.actorOf(ThurloeServiceActor.props(swaggerService))
+  val service = system.actorOf(ThurloeServiceActor.props(ConfigFactory.load()))
 
   implicit val timeout = Timeout(5.seconds)
   import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/main/scala/thurloe/service/ThurloeService.scala
+++ b/src/main/scala/thurloe/service/ThurloeService.scala
@@ -20,9 +20,7 @@ trait ThurloeService extends HttpService {
 
   val dataAccess: DataAccess
   val ThurloePrefix = "thurloe"
-  val Yaml = "thurloe.yaml"
   val Interjection = "Harumph!"
-  val Swagger = "swagger"
 
   val getRoute = path(ThurloePrefix / Segment / Segment) { (userId, key) =>
     get {
@@ -124,10 +122,6 @@ trait ThurloeService extends HttpService {
           }
       }
     }
-  }
-
-  def yamlRoute = path(Swagger / Yaml) {
-    getFromResource(s"$Swagger/$Yaml")
   }
 
   val keyValuePairRoutes = getRoute ~ getAllRoute ~ setRoute ~ deleteRoute

--- a/src/test/scala/thurloe/service/ThurloeServiceSpec.scala
+++ b/src/test/scala/thurloe/service/ThurloeServiceSpec.scala
@@ -1,6 +1,7 @@
 package thurloe.service
 
-import org.scalatest.FunSpec
+import org.scalatest.{Matchers, FlatSpec, FunSpec}
+import org.yaml.snakeyaml.Yaml
 import spray.http.StatusCodes
 import spray.testkit.ScalatestRouteTest
 import spray.httpx.SprayJsonSupport._
@@ -181,5 +182,46 @@ class ThurloeServiceSpec extends FunSpec with ScalatestRouteTest {
         }
       }
     }
+  }
+}
+
+class SwaggerServiceSpec extends FlatSpec with SwaggerService with ScalatestRouteTest with Matchers {
+  def actorRefFactory = system
+
+  "Cromwell swagger docs" should "return 200" in {
+    Get("/swagger/thurloe.yaml") ~>
+      swaggerUiResourceRoute ~>
+      check {
+        assertResult(StatusCodes.OK) {
+          status
+        }
+        assertResult("2.0") {
+          new Yaml()
+            .loadAs(responseAs[String], classOf[java.util.Map[String, AnyRef]])
+            .get("swagger")
+        }
+      }
+
+    Options("/swagger/thurloe.yaml") ~>
+      swaggerUiResourceRoute ~>
+      check {
+        assertResult(StatusCodes.OK) {
+          status
+        }
+        assertResult("OK") {
+          responseAs[String]
+        }
+      }
+
+    Get("/swagger/index.html") ~>
+      swaggerUiResourceRoute ~>
+      check {
+        assertResult(StatusCodes.OK) {
+          status
+        }
+        assertResult("<!DOCTYPE html>") {
+          responseAs[String].take(15)
+        }
+      }
   }
 }


### PR DESCRIPTION
Added config option 'api.routeUnwrapped' to optionally allow still serving original routes.
