### PR TITLE
Swagger needs all `HTTP OPTIONS` to return status 200.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val downgradedSprayV = "1.3.1"
 val akkaV = "2.3.12"
 val slickV = "3.1.0"
 
-val lenthallV = "0.14-6479841-SNAPSHOT"
+val lenthallV = "0.14-2ce072a-SNAPSHOT"
 
 resolvers ++= Seq(
   "Broad Artifactory Releases" at "https://artifactory.broadinstitute.org/artifactory/libs-release/",

--- a/src/test/scala/thurloe/service/ThurloeServiceSpec.scala
+++ b/src/test/scala/thurloe/service/ThurloeServiceSpec.scala
@@ -1,5 +1,6 @@
 package thurloe.service
 
+import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{Matchers, FlatSpec, FunSpec}
 import org.yaml.snakeyaml.Yaml
 import spray.http.StatusCodes
@@ -185,10 +186,11 @@ class ThurloeServiceSpec extends FunSpec with ScalatestRouteTest {
   }
 }
 
-class SwaggerServiceSpec extends FlatSpec with SwaggerService with ScalatestRouteTest with Matchers {
+class SwaggerServiceSpec extends FlatSpec with SwaggerService with ScalatestRouteTest with Matchers with
+TableDrivenPropertyChecks {
   def actorRefFactory = system
 
-  "Cromwell swagger docs" should "return 200" in {
+  "Thurloe swagger docs" should "return 200" in {
     Get("/swagger/thurloe.yaml") ~>
       swaggerUiResourceRoute ~>
       check {
@@ -202,17 +204,6 @@ class SwaggerServiceSpec extends FlatSpec with SwaggerService with ScalatestRout
         }
       }
 
-    Options("/swagger/thurloe.yaml") ~>
-      swaggerUiResourceRoute ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
-        }
-        assertResult("OK") {
-          responseAs[String]
-        }
-      }
-
     Get("/swagger/index.html") ~>
       swaggerUiResourceRoute ~>
       check {
@@ -223,5 +214,23 @@ class SwaggerServiceSpec extends FlatSpec with SwaggerService with ScalatestRout
           responseAs[String].take(15)
         }
       }
+  }
+
+  "Thurloe swagger route" should "return 200 for all options" in {
+    val pathExamples = Table("path", "/", "/swagger", "/swagger/thurloe.yaml", "/swagger/index.html", "/api",
+      "/api/thurloe/", "/thurloe")
+
+    forAll(pathExamples) { path =>
+      Options(path) ~>
+        swaggerUiResourceRoute ~>
+        check {
+          assertResult(StatusCodes.OK) {
+            status
+          }
+          assertResult("OK") {
+            responseAs[String]
+          }
+        }
+    }
   }
 }


### PR DESCRIPTION
Only temporary redirect `/` to `/swagger` during a `GET`.
