### PR TITLE
pin to sbt 0.13

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16


### PR DESCRIPTION
pin Thurloe to sbt 0.13. It fails to build with sbt 1.x.

This is useful for our own development. As well, our SourceClear security scanner tries to use sbt 1.x if a version is not specified - which means SourceClear can't build/scan this project as-is.