### PR TITLE
ID-361 Explicitly capture exceptions with sentry.

### DIFF
--- a/src/main/scala/thurloe/Main.scala
+++ b/src/main/scala/thurloe/Main.scala
@@ -19,7 +19,8 @@ object Main extends App {
   sys.env.get("SENTRY_DSN").foreach { dsn =>
     val options = new SentryOptions()
     options.setDsn(dsn)
-    Sentry.init()
+    options.setEnvironment(sys.env.getOrElse("SENTRY_ENVIRONMENT", "unknown"))
+    Sentry.init(options)
   }
 
   // We need an ActorSystem to host our application in

--- a/src/main/scala/thurloe/service/ThurloeService.scala
+++ b/src/main/scala/thurloe/service/ThurloeService.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import com.typesafe.scalalogging.LazyLogging
+import io.sentry.Sentry
 import spray.json._
 import thurloe.database.DatabaseOperation.DatabaseOperation
 import thurloe.database.{DataAccess, DatabaseOperation, KeyNotFoundException}
@@ -62,6 +63,7 @@ trait ThurloeService extends LazyLogging {
 
   private def handleError(e: Throwable) =
     extract(_.request) { request =>
+      Sentry.captureException(e)
       logger.error(s"error handling request: ${request.method} ${request.uri}", e)
       complete(StatusCodes.InternalServerError, s"$Interjection $e")
     }


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-361

  We never just throw exceptions when they happen we encapsulate them in IO's (or other monads) and bubble them up to an error handler. I think we havent been seeing sentry events bc we need to explicitly capture them with the sentry sdk in our error handlers.

---

- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
