### PR TITLE
Id 361 explicitly capture exceptions sentry 

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -30,16 +30,25 @@
         <suffixPattern>[%level] [%d{HH:mm:ss.SSS}] [%thread] %logger{36} - %msg%n</suffixPattern>
     </appender>
 
+    <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
+    <appender name="Sentry" class="com.getsentry.raven.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
     <logger name="org.broadinstitute.dsde" level="info" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>
+        <appender-ref ref="Sentry"/>
     </logger>
 
     <logger name="akka" level="info" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>
+        <appender-ref ref="Sentry"/>
     </logger>
 
     <!-- see https://github.com/slick/slick/blob/master/common-test-resources/logback.xml for more Slick logging -->
@@ -61,6 +70,7 @@
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>
         <appender-ref ref="SYSLOG"/>
+        <appender-ref ref="Sentry"/>
     </root>
 
 </configuration>

--- a/src/main/scala/thurloe/Main.scala
+++ b/src/main/scala/thurloe/Main.scala
@@ -19,7 +19,8 @@ object Main extends App {
   sys.env.get("SENTRY_DSN").foreach { dsn =>
     val options = new SentryOptions()
     options.setDsn(dsn)
-    Sentry.init()
+    options.setEnvironment(sys.env.getOrElse("SENTRY_ENVIRONMENT", "unknown"))
+    Sentry.init(options)
   }
 
   // We need an ActorSystem to host our application in

--- a/src/main/scala/thurloe/service/ThurloeService.scala
+++ b/src/main/scala/thurloe/service/ThurloeService.scala
@@ -5,7 +5,6 @@ import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import com.typesafe.scalalogging.LazyLogging
-import io.sentry.Sentry
 import spray.json._
 import thurloe.database.DatabaseOperation.DatabaseOperation
 import thurloe.database.{DataAccess, DatabaseOperation, KeyNotFoundException}
@@ -63,7 +62,6 @@ trait ThurloeService extends LazyLogging {
 
   private def handleError(e: Throwable) =
     extract(_.request) { request =>
-      Sentry.captureException(e)
       logger.error(s"error handling request: ${request.method} ${request.uri}", e)
       complete(StatusCodes.InternalServerError, s"$Interjection $e")
     }

--- a/src/main/scala/thurloe/service/ThurloeService.scala
+++ b/src/main/scala/thurloe/service/ThurloeService.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import com.typesafe.scalalogging.LazyLogging
+import io.sentry.Sentry
 import spray.json._
 import thurloe.database.DatabaseOperation.DatabaseOperation
 import thurloe.database.{DataAccess, DatabaseOperation, KeyNotFoundException}
@@ -62,6 +63,7 @@ trait ThurloeService extends LazyLogging {
 
   private def handleError(e: Throwable) =
     extract(_.request) { request =>
+      Sentry.captureException(e)
       logger.error(s"error handling request: ${request.method} ${request.uri}", e)
       complete(StatusCodes.InternalServerError, s"$Interjection $e")
     }


### PR DESCRIPTION
I added an explicit sentry issue capture call thinking that was the issue but sentry was misconfigured -- now I need to remove the explicit exception capturing bc otherwise we will get duplicates.

I added a sentry log appender which will capture exceptions from error logs, same as in sam.