### PR TITLE
ID-361 Add breadcrumbs and release hash for sentry.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.typesafe.akka" %% "akka-http-spray-json" % "10.2.9",
   "com.google.protobuf" % "protobuf-java" % "4.0.0-rc-2",
-  "io.sentry" % "sentry" % "6.9.2",
+  "io.sentry" % "sentry" % "6.15.0",
+  "io.sentry" % "sentry-logback" % "6.15.0",
   "org.broadinstitute.dsde.workbench" %%  "workbench-google" % workbenchGoogleV
     exclude("com.typesafe.akka", "akka-protobuf-v3_2.13")
     exclude("com.google.protobuf", "protobuf-java")

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -31,7 +31,7 @@
     </appender>
 
     <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
-    <appender name="Sentry" class="com.getsentry.raven.logback.SentryAppender">
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
         </filter>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -35,6 +35,7 @@
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
         </filter>
+        <minimumBreadcrumbLevel>DEBUG</minimumBreadcrumbLevel>
     </appender>
 
     <logger name="org.broadinstitute.dsde" level="info" additivity="false">

--- a/src/main/scala/thurloe/Main.scala
+++ b/src/main/scala/thurloe/Main.scala
@@ -16,10 +16,13 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.jdk.CollectionConverters._
 
 object Main extends App {
+  val releaseHash: Option[String] = sys.env.get("GIT_SHA")
   sys.env.get("SENTRY_DSN").foreach { dsn =>
     val options = new SentryOptions()
     options.setDsn(dsn)
     options.setEnvironment(sys.env.getOrElse("SENTRY_ENVIRONMENT", "unknown"))
+    releaseHash.foreach(options.setRelease)
+
     Sentry.init(options)
   }
 

--- a/src/main/scala/thurloe/Main.scala
+++ b/src/main/scala/thurloe/Main.scala
@@ -16,12 +16,13 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.jdk.CollectionConverters._
 
 object Main extends App {
-  val releaseHash: Option[String] = sys.env.get("GIT_SHA")
+  val version: Option[String] = Option(getClass.getPackage.getImplementationVersion)
+
   sys.env.get("SENTRY_DSN").foreach { dsn =>
     val options = new SentryOptions()
     options.setDsn(dsn)
     options.setEnvironment(sys.env.getOrElse("SENTRY_ENVIRONMENT", "unknown"))
-    releaseHash.foreach(options.setRelease)
+    options.setRelease(version.getOrElse("unknown"))
 
     Sentry.init(options)
   }


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-361

Duplicates the setup in sam to add logback support, release hash, breadcrumbs. Basically more sentry features.

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
