### PR TITLE
[DDO-2787] Allow Thurloe to be passed environment variables with periods in them 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,17 @@ RUN mkdir /thurloe
 COPY ./thurloe*.jar /thurloe
 
 # Start up Thurloe
-CMD java $JAVA_OPTS -jar $(find /thurloe -name 'thurloe*.jar')
+# 1. “Exec” form of CMD necessary to avoid “shell” form’s `sh` stripping 
+#    environment variables with periods in them, often used in DSP for Lightbend 
+#    config.
+# 2. Handling $JAVA_OPTS is necessary as long as firecloud-develop or the app’s 
+#    chart tries to set it. Apps that use devops’s foundation subchart don’t need 
+#    to handle this.
+# 3. The jar’s location and naming scheme in the filesystem is required by preflight 
+#    liquibase migrations in some app charts. Apps that expose liveness endpoints 
+#    may not need preflight liquibase migrations.
+# We use the “exec” form with `bash` to accomplish all of the above.
+CMD ["/bin/bash", "-c", "java $JAVA_OPTS -jar $(find /thurloe -name 'thurloe*.jar')"]
 
 # These next 4 commands are for enabling SSH to the container.
 # id_rsa.pub is referenced below, but this should be any public key


### PR DESCRIPTION
Ticket: [broadworkbench.atlassian.net/browse/DDO-2787](https://broadworkbench.atlassian.net/browse/DDO-2787)

What:

Allows Orch to be passed environment variables with periods in them.

Why:

Lightbend config expects folks to configure array fields by passing environment variables with periods in them. I'm standardizing this as much as I can, regardless of whether the app actually needs to use this. I just don't think we should have arbitrary differences between Dockerfiles, it'll just trip someone up at some point.

How:

Use bash instead of the implicit sh for the Dockerfile's CMD.

Like https://github.com/DataBiosphere/leonardo/pull/3291, https://github.com/broadinstitute/sam/pull/1060, https://github.com/broadinstitute/rawls/pull/2328, https://github.com/broadinstitute/firecloud-orchestration/pull/1132

---

- [x] **Submitter**: Make sure Swagger is updated if API changes

> No API changes!

- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)

> No changes!

- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails

> No need, talked with appsec

- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them

> No new libraries!
