### PR TITLE
ID-728 Add sam lookup to support azure user notifications.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ libraryDependencies ++= Seq(
   "org.hsqldb" % "hsqldb" % "2.6.1",
   "com.sendgrid" % "sendgrid-java" % "2.2.2",
   "ch.qos.logback" % "logback-classic" % "1.2.10",
-  "org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-e57a8f1-SNAP",
+  "org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-0c156f9-SNAP",
 //---------- Test libraries -------------------//
   "org.broadinstitute.dsde.workbench" %%  "workbench-google" % workbenchGoogleV % Test classifier "tests",
   "com.typesafe.akka" %% "akka-testkit" % akkaV % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ libraryDependencies ++= Seq(
   "org.hsqldb" % "hsqldb" % "2.6.1",
   "com.sendgrid" % "sendgrid-java" % "2.2.2",
   "ch.qos.logback" % "logback-classic" % "1.2.10",
-  "org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-0c156f9-SNAP",
+  "org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-4cde1ff",
 //---------- Test libraries -------------------//
   "org.broadinstitute.dsde.workbench" %%  "workbench-google" % workbenchGoogleV % Test classifier "tests",
   "com.typesafe.akka" %% "akka-testkit" % akkaV % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -109,6 +109,7 @@ val customMergeStrategy: String => MergeStrategy = {
       case p :: Nil if p.endsWith(".rsa") || p.endsWith(".sf") || p.endsWith(".dsa") => MergeStrategy.discard
       case _ => MergeStrategy.first
     }
+  case PathList("javax", "annotation", _@_*) => MergeStrategy.first
   case "NOTICE" => MergeStrategy.discard
   case "module-info.class" => MergeStrategy.discard
   case "reference.conf" => MergeStrategy.concat

--- a/build.sbt
+++ b/build.sbt
@@ -49,11 +49,13 @@ libraryDependencies ++= Seq(
   "org.hsqldb" % "hsqldb" % "2.6.1",
   "com.sendgrid" % "sendgrid-java" % "2.2.2",
   "ch.qos.logback" % "logback-classic" % "1.2.10",
-  //---------- Test libraries -------------------//
+  "org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-e57a8f1-SNAP",
+//---------- Test libraries -------------------//
   "org.broadinstitute.dsde.workbench" %%  "workbench-google" % workbenchGoogleV % Test classifier "tests",
   "com.typesafe.akka" %% "akka-testkit" % akkaV % Test,
   "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % Test,
   "org.scalatest" %% "scalatest" % scalaTestV % Test,
+  "org.mockito" %% "mockito-scala-scalatest" % "1.17.12" % Test,
   "org.yaml" % "snakeyaml" % "1.33" % Test
 )
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,3 +1,6 @@
+sam {
+    baseUrl = "https://sam.dsde-dev.broadinstitute.org/"
+}
 
 swagger {
   docsPath = "swagger/thurloe.yaml"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,8 +1,3 @@
-sam {
-    baseUrl = "https://sam.dsde-dev.broadinstitute.org/"
-    pathToPem = "fake/path/pem"
-}
-
 swagger {
   docsPath = "swagger/thurloe.yaml"
   uiVersion = "2.1.1"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,6 @@
 sam {
     baseUrl = "https://sam.dsde-dev.broadinstitute.org/"
+    pathToPem = "fake/path/pem"
 }
 
 swagger {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,6 +3,11 @@ swagger {
   uiVersion = "2.1.1"
 }
 
+sam {
+    samBaseUrl = ${?SAM_BASE_URL}
+    timeout=60s
+}
+
 database {
   config = hsqldb
 

--- a/src/main/scala/thurloe/Main.scala
+++ b/src/main/scala/thurloe/Main.scala
@@ -40,7 +40,7 @@ object Main extends App {
     gcsConfig.getString("serviceProject")
   )
 
-  implicit val samDao = new HttpSamDAO(config)
+  implicit val samDao = new HttpSamDAO(config, pem)
   private val httpSendGridDAO = new HttpSendGridDAO
   system.actorOf(
     NotificationMonitorSupervisor.props(

--- a/src/main/scala/thurloe/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/HttpSamDAO.scala
@@ -28,9 +28,6 @@ class HttpSamDAO(config: Config) extends SamDAO with LazyLogging {
 
   private val okHttpClient = new ApiClient().getHttpClient
 
-  val scopes =
-    List("https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile")
-
   protected def getApiClient(): ApiClient = {
 
     val okHttpClientWithTracingBuilder = okHttpClient.newBuilder
@@ -38,7 +35,7 @@ class HttpSamDAO(config: Config) extends SamDAO with LazyLogging {
 
     val samApiClient = new ApiClient(okHttpClientWithTracingBuilder.protocols(Seq(Protocol.HTTP_1_1).asJava).build())
     samApiClient.setBasePath(samServiceURL)
-    samApiClient.setAccessToken(credentials.toGoogleCredential(scopes).getAccessToken)
+    samApiClient.setAccessToken(credentials.toGoogleCredential(List.empty).getAccessToken)
 
     samApiClient
   }

--- a/src/main/scala/thurloe/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/HttpSamDAO.scala
@@ -1,0 +1,42 @@
+package thurloe.dataaccess
+
+import com.typesafe.scalalogging.LazyLogging
+import okhttp3.Protocol
+import org.broadinstitute.dsde.workbench.client.sam
+import org.broadinstitute.dsde.workbench.client.sam.ApiClient
+import org.broadinstitute.dsde.workbench.client.sam.api.AdminApi
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.GoogleCredentialMode
+
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters._
+import scala.jdk.DurationConverters._
+
+class HttpSamDAO(baseSamServiceURL: String, credentials: GoogleCredentialMode, timeout: FiniteDuration)
+    extends SamDAO
+    with LazyLogging {
+
+  private val samServiceURL = baseSamServiceURL
+
+  private val okHttpClient = new ApiClient().getHttpClient
+
+  val scopes =
+    List("https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile")
+
+  protected def getApiClient(): ApiClient = {
+
+    val okHttpClientWithTracingBuilder = okHttpClient.newBuilder
+      .readTimeout(timeout.toJava)
+
+    val samApiClient = new ApiClient(okHttpClientWithTracingBuilder.protocols(Seq(Protocol.HTTP_1_1).asJava).build())
+    samApiClient.setBasePath(samServiceURL)
+    samApiClient.setAccessToken(credentials.toGoogleCredential(scopes).getAccessToken)
+
+    samApiClient
+  }
+
+  protected def adminApi() = new AdminApi(getApiClient())
+
+  override def getUserById(userId: String): List[sam.model.User] =
+    adminApi().adminGetUserByQuery(userId, userId, userId).asScala.toList
+
+}

--- a/src/main/scala/thurloe/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/HttpSamDAO.scala
@@ -1,21 +1,30 @@
 package thurloe.dataaccess
 
+import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import okhttp3.Protocol
 import org.broadinstitute.dsde.workbench.client.sam
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient
 import org.broadinstitute.dsde.workbench.client.sam.api.AdminApi
-import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.GoogleCredentialMode
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
-import scala.concurrent.duration.FiniteDuration
+import java.io.File
 import scala.jdk.CollectionConverters._
 import scala.jdk.DurationConverters._
 
-class HttpSamDAO(baseSamServiceURL: String, credentials: GoogleCredentialMode, timeout: FiniteDuration)
-    extends SamDAO
-    with LazyLogging {
+class HttpSamDAO(config: Config) extends SamDAO with LazyLogging {
 
-  private val samServiceURL = baseSamServiceURL
+  val gcsConfig = config.getConfig("gcs")
+  val samConfig = config.getConfig("sam")
+
+  // GCS config
+  val credentials =
+    GoogleCredentialModes.Pem(WorkbenchEmail(gcsConfig.getString("clientEmail")),
+                              new File(gcsConfig.getString("pathToPem")))
+
+  private val samServiceURL = samConfig.getString("samBaseUrl")
+  private val timeout = samConfig.getDuration("timeout").toScala
 
   private val okHttpClient = new ApiClient().getHttpClient
 

--- a/src/main/scala/thurloe/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/HttpSamDAO.scala
@@ -30,6 +30,6 @@ class HttpSamDAO(config: Config, credentials: GoogleCredentialModes.Pem) extends
   protected def adminApi() = new AdminApi(samApiClient)
 
   override def getUserById(userId: String): List[sam.model.User] =
-    adminApi().adminGetUserByQuery(userId, userId, userId).asScala.toList
+    adminApi().adminGetUsersByQuery(userId, userId, userId, 5).asScala.toList
 
 }

--- a/src/main/scala/thurloe/dataaccess/HttpSendGridDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/HttpSendGridDAO.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 /**
  * Created by mbemis on 6/16/16.
  */
-class HttpSendGridDAO(implicit samDAO: SamDAO) extends SendGridDAO with LazyLogging {
+class HttpSendGridDAO(samDao: SamDAO) extends SendGridDAO with LazyLogging {
   val dataAccess = ThurloeDatabaseConnector
 
   override def sendEmail(email: SendGrid.Email): Future[Response] = {
@@ -35,7 +35,7 @@ class HttpSendGridDAO(implicit samDAO: SamDAO) extends SendGridDAO with LazyLogg
   //Looks up a KVP, converting empty values or missing KVPs into None
   private def lookupNonEmptyKeyValuePair(userId: String, key: String) =
     dataAccess
-      .lookup(userId, key)
+      .lookup(samDao, userId, key)
       .map { kvp =>
         if (kvp.keyValuePair.value.isEmpty) None
         else Some(kvp)
@@ -66,12 +66,12 @@ class HttpSendGridDAO(implicit samDAO: SamDAO) extends SendGridDAO with LazyLogg
 
   def lookupUserName(userId: WorkbenchUserId): Future[String] =
     for {
-      firstName <- dataAccess.lookup(userId.value, "firstName")
-      lastName <- dataAccess.lookup(userId.value, "lastName")
+      firstName <- dataAccess.lookup(samDao, userId.value, "firstName")
+      lastName <- dataAccess.lookup(samDao, userId.value, "lastName")
     } yield s"${firstName.keyValuePair.value} ${lastName.keyValuePair.value}"
 
   def lookupUserFirstName(userId: WorkbenchUserId): Future[String] =
     for {
-      firstName <- dataAccess.lookup(userId.value, "firstName")
+      firstName <- dataAccess.lookup(samDao, userId.value, "firstName")
     } yield firstName.keyValuePair.value
 }

--- a/src/main/scala/thurloe/dataaccess/HttpSendGridDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/HttpSendGridDAO.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 /**
  * Created by mbemis on 6/16/16.
  */
-class HttpSendGridDAO extends SendGridDAO with LazyLogging {
+class HttpSendGridDAO(implicit samDAO: SamDAO) extends SendGridDAO with LazyLogging {
   val dataAccess = ThurloeDatabaseConnector
 
   override def sendEmail(email: SendGrid.Email): Future[Response] = {

--- a/src/main/scala/thurloe/dataaccess/SamDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/SamDAO.scala
@@ -1,0 +1,8 @@
+package thurloe.dataaccess
+
+import org.broadinstitute.dsde.workbench.client.sam
+
+trait SamDAO {
+  def getUserById(userId: String): List[sam.model.User]
+
+}

--- a/src/main/scala/thurloe/database/DataAccess.scala
+++ b/src/main/scala/thurloe/database/DataAccess.scala
@@ -7,12 +7,10 @@ import thurloe.service.{ThurloeQuery, UserKeyValuePair, UserKeyValuePairs}
 import scala.concurrent.Future
 
 trait DataAccess {
-  val samDAO: SamDAO
-
-  def set(keyValuePairs: UserKeyValuePairs): Future[DatabaseOperation]
-  def lookup(userId: String, key: String): Future[UserKeyValuePair]
-  def lookup(userId: String): Future[UserKeyValuePairs]
-  def lookup(query: ThurloeQuery): Future[Seq[UserKeyValuePair]]
+  def set(keyValuePairs: UserKeyValuePairs)(implicit samDAO: SamDAO): Future[DatabaseOperation]
+  def lookup(userId: String, key: String)(implicit samDAO: SamDAO): Future[UserKeyValuePair]
+  def lookup(userId: String)(implicit samDAO: SamDAO): Future[UserKeyValuePairs]
+  def lookup(query: ThurloeQuery)(implicit samDAO: SamDAO): Future[Seq[UserKeyValuePair]]
   def delete(userId: String, key: String): Future[Unit]
   def status(): Future[Unit]
 }

--- a/src/main/scala/thurloe/database/DataAccess.scala
+++ b/src/main/scala/thurloe/database/DataAccess.scala
@@ -1,11 +1,13 @@
 package thurloe.database
 
+import thurloe.dataaccess.SamDAO
 import thurloe.database.DatabaseOperation.DatabaseOperation
 import thurloe.service.{ThurloeQuery, UserKeyValuePair, UserKeyValuePairs}
 
 import scala.concurrent.Future
 
 trait DataAccess {
+  val samDAO: SamDAO
 
   def set(keyValuePairs: UserKeyValuePairs): Future[DatabaseOperation]
   def lookup(userId: String, key: String): Future[UserKeyValuePair]

--- a/src/main/scala/thurloe/database/DataAccess.scala
+++ b/src/main/scala/thurloe/database/DataAccess.scala
@@ -7,10 +7,10 @@ import thurloe.service.{ThurloeQuery, UserKeyValuePair, UserKeyValuePairs}
 import scala.concurrent.Future
 
 trait DataAccess {
-  def set(keyValuePairs: UserKeyValuePairs)(implicit samDAO: SamDAO): Future[DatabaseOperation]
-  def lookup(userId: String, key: String)(implicit samDAO: SamDAO): Future[UserKeyValuePair]
-  def lookup(userId: String)(implicit samDAO: SamDAO): Future[UserKeyValuePairs]
-  def lookup(query: ThurloeQuery)(implicit samDAO: SamDAO): Future[Seq[UserKeyValuePair]]
+  def set(samDao: SamDAO, keyValuePairs: UserKeyValuePairs): Future[DatabaseOperation]
+  def lookup(samDao: SamDAO, userId: String, key: String): Future[UserKeyValuePair]
+  def lookup(samDao: SamDAO, userId: String): Future[UserKeyValuePairs]
+  def lookup(samDao: SamDAO, query: ThurloeQuery): Future[Seq[UserKeyValuePair]]
   def delete(userId: String, key: String): Future[Unit]
   def status(): Future[Unit]
 }

--- a/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
+++ b/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
@@ -105,7 +105,7 @@ case object ThurloeDatabaseConnector extends DataAccess with LazyLogging {
       } else {
         Future.failed(InvalidDatabaseStateException(s"Too many results: ${results.size}"))
       }
-    } yield result
+    } yield result.copy(userKeyValuePair = result.userKeyValuePair.copy(userId = userId))
 
   def lookup(userId: String, key: String)(implicit samDAO: SamDAO): Future[UserKeyValuePair] =
     lookupIncludingDatabaseId(userId, key) map {

--- a/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
+++ b/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
@@ -147,10 +147,10 @@ case object ThurloeDatabaseConnector extends DataAccess with LazyLogging {
       filteredOnUserAndKey <- lookupWithConstraint(userIdAndKeyConstraint(queryParameters))
       // We have to filter out values outside of the Slick access because the values are encrypted until now.
       valueFilter = (userKeyValuePair: UserKeyValuePairWithId) =>
-        queryParameters.value forall { values =>
+        queryParameters.value map { values =>
           val valueFilters = values map { value => value.equals(userKeyValuePair.userKeyValuePair.keyValuePair.value) }
           valueFilters.reduceLeft(_ || _)
-        }
+        } getOrElse true
       results = filteredOnUserAndKey filter valueFilter
     } yield results map { _.userKeyValuePair }
   }

--- a/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
+++ b/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
@@ -60,7 +60,7 @@ case object ThurloeDatabaseConnector extends DataAccess with LazyLogging {
     }
 
   /**
-   * Consumers of thurloe are not cinsistent in what type of userId they send. Sometimes it is the user's
+   * Consumers of thurloe are not consistent in what type of userId they send. Sometimes it is the user's
    * googleSubjectId and sometimes it is the user's azureB2cId. This method will look up the user in sam to get
    * all of their ids in order to properly do the lookup and support azure b2c users.
    *

--- a/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
+++ b/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
@@ -88,9 +88,9 @@ case object ThurloeDatabaseConnector extends DataAccess with LazyLogging {
           Future.failed(
             InvalidDatabaseStateException(
               s"Too many results returned from sam, none of which have an AzureB2cId: ${results.size}." +
-                s"Results: ${results
+                s"\nResults: ${results
                   .map(samRecord => s"GoogleSubjectId: ${samRecord.getGoogleSubjectId}, AzureB2cId: ${samRecord.getAzureB2CId}, SamId: ${samRecord.getId}")}" +
-                s"Query: $userId"
+                s"\nQuery: $userId"
             )
           )
         )
@@ -127,7 +127,7 @@ case object ThurloeDatabaseConnector extends DataAccess with LazyLogging {
         Future.failed(
           InvalidDatabaseStateException(
             s"Too many results returned from Thurloe's DB (${results.size}) for userId: $userId and key: $key" +
-              s"Results: ${results.map(thurloeRecord => s"KeyValuePair: ${thurloeRecord.userKeyValuePair}")}"
+              s"\nResults: ${results.map(thurloeRecord => s"KeyValuePair: ${thurloeRecord.userKeyValuePair}")}"
           )
         )
       }

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -10,7 +10,7 @@ import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO.PubSubMessage
 import org.broadinstitute.dsde.workbench.model.Notifications._
 import org.broadinstitute.dsde.workbench.model.WorkbenchUserId
 import spray.json._
-import thurloe.dataaccess.SendGridDAO
+import thurloe.dataaccess.{SamDAO, SendGridDAO}
 import thurloe.database.{DataAccess, KeyNotFoundException, ThurloeDatabaseConnector}
 import thurloe.notification.NotificationMonitor.StartMonitorPass
 import thurloe.notification.NotificationMonitorSupervisor._
@@ -34,7 +34,7 @@ object NotificationMonitorSupervisor {
             workerCount: Int,
             sendGridDAO: SendGridDAO,
             templateIdsByType: Map[String, String],
-            fireCloudPortalUrl: String)(implicit executionContext: ExecutionContext): Props =
+            fireCloudPortalUrl: String)(implicit executionContext: ExecutionContext, samDAO: SamDAO): Props =
     Props(
       new NotificationMonitorSupervisor(pollInterval,
                                         pollIntervalJitter,
@@ -48,15 +48,17 @@ object NotificationMonitorSupervisor {
     )
 }
 
-class NotificationMonitorSupervisor(val pollInterval: FiniteDuration,
-                                    pollIntervalJitter: FiniteDuration,
-                                    pubSubDao: GooglePubSubDAO,
-                                    pubSubTopicName: String,
-                                    pubSubSubscriptionName: String,
-                                    workerCount: Int,
-                                    sendGridDAO: SendGridDAO,
-                                    templateIdsByType: Map[String, String],
-                                    fireCloudPortalUrl: String)(implicit executionContext: ExecutionContext)
+class NotificationMonitorSupervisor(
+  val pollInterval: FiniteDuration,
+  pollIntervalJitter: FiniteDuration,
+  pubSubDao: GooglePubSubDAO,
+  pubSubTopicName: String,
+  pubSubSubscriptionName: String,
+  workerCount: Int,
+  sendGridDAO: SendGridDAO,
+  templateIdsByType: Map[String, String],
+  fireCloudPortalUrl: String
+)(implicit executionContext: ExecutionContext, samDao: SamDAO)
     extends Actor
     with LazyLogging {
 
@@ -110,7 +112,7 @@ object NotificationMonitor {
             sendGridDAO: SendGridDAO,
             templateIdsByType: Map[String, String],
             fireCloudPortalUrl: String,
-            dataAccess: DataAccess)(implicit executionContext: ExecutionContext): Props =
+            dataAccess: DataAccess)(implicit executionContext: ExecutionContext, samDAO: SamDAO): Props =
     Props(
       new NotificationMonitorActor(pollInterval,
                                    pollIntervalJitter,
@@ -132,7 +134,7 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
                                sendGridDAO: SendGridDAO,
                                templateIdsByType: Map[String, String],
                                fireCloudPortalUrl: String,
-                               dataAccess: DataAccess)(implicit executionContext: ExecutionContext)
+                               dataAccess: DataAccess)(implicit executionContext: ExecutionContext, samDao: SamDAO)
     extends Actor
     with LazyLogging {
 

--- a/src/main/scala/thurloe/service/ThurloeService.scala
+++ b/src/main/scala/thurloe/service/ThurloeService.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.server.Route
 import com.typesafe.scalalogging.LazyLogging
 import io.sentry.Sentry
 import spray.json._
+import thurloe.dataaccess.SamDAO
 import thurloe.database.DatabaseOperation.DatabaseOperation
 import thurloe.database.{DataAccess, DatabaseOperation, KeyNotFoundException}
 import thurloe.service.ApiDataModelsJsonProtocol._
@@ -16,6 +17,7 @@ import scala.util.{Failure, Success}
 
 trait ThurloeService extends LazyLogging {
 
+  implicit val samDao: SamDAO
   val dataAccess: DataAccess
   val ThurloePrefix = "thurloe"
   val Interjection = "Harumph!"

--- a/src/main/scala/thurloe/service/ThurloeService.scala
+++ b/src/main/scala/thurloe/service/ThurloeService.scala
@@ -17,7 +17,7 @@ import scala.util.{Failure, Success}
 
 trait ThurloeService extends LazyLogging {
 
-  implicit val samDao: SamDAO
+  val samDao: SamDAO
   val dataAccess: DataAccess
   val ThurloePrefix = "thurloe"
   val Interjection = "Harumph!"
@@ -25,7 +25,7 @@ trait ThurloeService extends LazyLogging {
   val getRoute: Route =
     path(ThurloePrefix / Segment / Segment) { (userId, key) =>
       get {
-        val query: Future[UserKeyValuePair] = dataAccess.lookup(userId, key)
+        val query: Future[UserKeyValuePair] = dataAccess.lookup(samDao, userId, key)
         onComplete(query) {
           case Success(keyValuePair) =>
             complete(HttpEntity(ContentTypes.`application/json`, keyValuePair.toJson.prettyPrint))
@@ -50,7 +50,7 @@ trait ThurloeService extends LazyLogging {
               case Some(invalidFilters) =>
                 complete(StatusCodes.BadRequest, "Bad query parameter(s): " + invalidFilters.mkString(","))
               case None =>
-                val query: Future[Seq[UserKeyValuePair]] = dataAccess.lookup(ThurloeQuery(parameters))
+                val query: Future[Seq[UserKeyValuePair]] = dataAccess.lookup(samDao, ThurloeQuery(parameters))
                 onComplete(query) {
                   case Success(keyValuePairs: Seq[UserKeyValuePair]) =>
                     complete(HttpEntity(ContentTypes.`application/json`, keyValuePairs.toJson.prettyPrint))
@@ -73,7 +73,7 @@ trait ThurloeService extends LazyLogging {
   val getAllRoute: Route =
     path(ThurloePrefix / Segment) { (userId) =>
       get {
-        onComplete(dataAccess.lookup(userId)) {
+        onComplete(dataAccess.lookup(samDao, userId)) {
           case Success(userKeyValuePairs) =>
             complete(HttpEntity(ContentTypes.`application/json`, userKeyValuePairs.toJson.prettyPrint))
           case Failure(e) =>
@@ -93,7 +93,7 @@ trait ThurloeService extends LazyLogging {
     path(ThurloePrefix) {
       post {
         entity(as[UserKeyValuePairs]) { keyValuePairs =>
-          onComplete(dataAccess.set(keyValuePairs)) {
+          onComplete(dataAccess.set(samDao, keyValuePairs)) {
             case Success(setKeyResponse) =>
               complete(statusCode(setKeyResponse), HttpEntity(ContentTypes.`application/json`, ""))
             case Failure(e) =>

--- a/src/main/scala/thurloe/service/ThurloeServiceActor.scala
+++ b/src/main/scala/thurloe/service/ThurloeServiceActor.scala
@@ -5,14 +5,15 @@ import akka.http.scaladsl.server.Route
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
-import thurloe.dataaccess.HttpSendGridDAO
+import thurloe.dataaccess.{HttpSendGridDAO, SamDAO}
 import thurloe.database.ThurloeDatabaseConnector
 
-class ThurloeServiceActor extends FireCloudProtectedServices with StatusService {
+class ThurloeServiceActor(implicit httpSamDao: SamDAO) extends FireCloudProtectedServices with StatusService {
   val authConfig = ConfigFactory.load().getConfig("auth")
 
+  implicit val samDao = httpSamDao
   override val dataAccess = ThurloeDatabaseConnector
-  override val sendGridDAO = new HttpSendGridDAO
+  override val sendGridDAO = new HttpSendGridDAO()(samDao)
   protected val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/4.1.3"
 
   def route: Route =

--- a/src/main/scala/thurloe/service/ThurloeServiceActor.scala
+++ b/src/main/scala/thurloe/service/ThurloeServiceActor.scala
@@ -8,12 +8,12 @@ import com.typesafe.config.ConfigFactory
 import thurloe.dataaccess.{HttpSendGridDAO, SamDAO}
 import thurloe.database.ThurloeDatabaseConnector
 
-class ThurloeServiceActor(implicit httpSamDao: SamDAO) extends FireCloudProtectedServices with StatusService {
+class ThurloeServiceActor(httpSamDao: SamDAO) extends FireCloudProtectedServices with StatusService {
   val authConfig = ConfigFactory.load().getConfig("auth")
 
-  implicit val samDao = httpSamDao
+  val samDao = httpSamDao
   override val dataAccess = ThurloeDatabaseConnector
-  override val sendGridDAO = new HttpSendGridDAO()(samDao)
+  override val sendGridDAO = new HttpSendGridDAO(samDao)
   protected val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/4.1.3"
 
   def route: Route =

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <!-- See http://logback.qos.ch/manual/layouts.html -->
+            <!-- See http://doc.akka.io/docs/akka/2.0/scala/logging.html -->
+            <pattern>[%level] [%d{HH:mm:ss.SSS}] [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+</configuration>
+
+

--- a/src/test/scala/thurloe/database/MockThurloeDatabaseConnector.scala
+++ b/src/test/scala/thurloe/database/MockThurloeDatabaseConnector.scala
@@ -3,10 +3,11 @@ package thurloe.database
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import thurloe.dataaccess.{HttpSamDAO, SamDAO}
-import thurloe.service.{ThurloeQuery, UserKeyValuePairs}
+import thurloe.service.{ThurloeQuery, UserKeyValuePair, UserKeyValuePairs}
 
 import scala.concurrent.Future
 import org.mockito.MockitoSugar.mock
+import thurloe.database.DatabaseOperation.DatabaseOperation
 
 case object MockThurloeDatabaseConnector extends DataAccess {
   val samDAO = mock[HttpSamDAO]
@@ -14,13 +15,13 @@ case object MockThurloeDatabaseConnector extends DataAccess {
   // By default return no users
   when(samDAO.getUserById(any[String])).thenReturn(List.empty)
 
-  override def set(keyValuePairs: UserKeyValuePairs)(implicit samDao: SamDAO) = ???
+  override def set(samDao: SamDAO, keyValuePairs: UserKeyValuePairs): Future[DatabaseOperation] = ???
 
-  override def lookup(userId: String, key: String)(implicit samDao: SamDAO) = ???
+  override def lookup(samDao: SamDAO, userId: String, key: String): Future[UserKeyValuePair] = ???
 
-  override def lookup(userId: String)(implicit samDao: SamDAO) = ???
+  override def lookup(samDao: SamDAO, userId: String): Future[UserKeyValuePairs] = ???
 
-  override def lookup(query: ThurloeQuery)(implicit samDao: SamDAO) = ???
+  override def lookup(samDao: SamDAO, query: ThurloeQuery): Future[Seq[UserKeyValuePair]] = ???
 
   override def delete(userId: String, key: String) = ???
 

--- a/src/test/scala/thurloe/database/MockThurloeDatabaseConnector.scala
+++ b/src/test/scala/thurloe/database/MockThurloeDatabaseConnector.scala
@@ -1,10 +1,19 @@
 package thurloe.database
 
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import thurloe.dataaccess.HttpSamDAO
 import thurloe.service.{ThurloeQuery, UserKeyValuePairs}
 
 import scala.concurrent.Future
+import org.mockito.MockitoSugar.mock
 
 case object MockThurloeDatabaseConnector extends DataAccess {
+  val samDAO = mock[HttpSamDAO]
+
+  // By default return no users
+  when(samDAO.getUserById(any[String])).thenReturn(List.empty)
+
   override def set(keyValuePairs: UserKeyValuePairs) = ???
 
   override def lookup(userId: String, key: String) = ???

--- a/src/test/scala/thurloe/database/MockThurloeDatabaseConnector.scala
+++ b/src/test/scala/thurloe/database/MockThurloeDatabaseConnector.scala
@@ -2,7 +2,7 @@ package thurloe.database
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import thurloe.dataaccess.HttpSamDAO
+import thurloe.dataaccess.{HttpSamDAO, SamDAO}
 import thurloe.service.{ThurloeQuery, UserKeyValuePairs}
 
 import scala.concurrent.Future
@@ -14,13 +14,13 @@ case object MockThurloeDatabaseConnector extends DataAccess {
   // By default return no users
   when(samDAO.getUserById(any[String])).thenReturn(List.empty)
 
-  override def set(keyValuePairs: UserKeyValuePairs) = ???
+  override def set(keyValuePairs: UserKeyValuePairs)(implicit samDao: SamDAO) = ???
 
-  override def lookup(userId: String, key: String) = ???
+  override def lookup(userId: String, key: String)(implicit samDao: SamDAO) = ???
 
-  override def lookup(userId: String) = ???
+  override def lookup(userId: String)(implicit samDao: SamDAO) = ???
 
-  override def lookup(query: ThurloeQuery) = ???
+  override def lookup(query: ThurloeQuery)(implicit samDao: SamDAO) = ???
 
   override def delete(userId: String, key: String) = ???
 

--- a/src/test/scala/thurloe/database/MockUnhealthyThurloeDatabaseConnector.scala
+++ b/src/test/scala/thurloe/database/MockUnhealthyThurloeDatabaseConnector.scala
@@ -2,21 +2,24 @@ package thurloe.database
 
 import org.mockito.MockitoSugar.mock
 import thurloe.dataaccess.{HttpSamDAO, SamDAO}
-import thurloe.service.{ThurloeQuery, UserKeyValuePairs}
+import thurloe.database.DatabaseOperation.DatabaseOperation
+import thurloe.service.{ThurloeQuery, UserKeyValuePair, UserKeyValuePairs}
 
 import scala.concurrent.Future
 
 case object MockUnhealthyThurloeDatabaseConnector extends DataAccess {
   val samDAO = mock[HttpSamDAO]
-  override def set(keyValuePairs: UserKeyValuePairs)(implicit samDao: SamDAO) =
+  override def set(samDao: SamDAO, keyValuePairs: UserKeyValuePairs): Future[DatabaseOperation] =
     Future.failed(new Exception("does not work"))
 
-  override def lookup(userId: String, key: String)(implicit samDao: SamDAO) =
+  override def lookup(samDao: SamDAO, userId: String, key: String): Future[UserKeyValuePair] =
     Future.failed(new Exception("does not work"))
 
-  override def lookup(userId: String)(implicit samDao: SamDAO) = Future.failed(new Exception("does not work"))
+  override def lookup(samDao: SamDAO, userId: String): Future[UserKeyValuePairs] =
+    Future.failed(new Exception("does not work"))
 
-  override def lookup(query: ThurloeQuery)(implicit samDao: SamDAO) = Future.failed(new Exception("does not work"))
+  override def lookup(samDao: SamDAO, query: ThurloeQuery): Future[Seq[UserKeyValuePair]] =
+    Future.failed(new Exception("does not work"))
 
   override def delete(userId: String, key: String) = Future.failed(new Exception("does not work"))
 

--- a/src/test/scala/thurloe/database/MockUnhealthyThurloeDatabaseConnector.scala
+++ b/src/test/scala/thurloe/database/MockUnhealthyThurloeDatabaseConnector.scala
@@ -1,20 +1,22 @@
 package thurloe.database
 
 import org.mockito.MockitoSugar.mock
-import thurloe.dataaccess.HttpSamDAO
+import thurloe.dataaccess.{HttpSamDAO, SamDAO}
 import thurloe.service.{ThurloeQuery, UserKeyValuePairs}
 
 import scala.concurrent.Future
 
 case object MockUnhealthyThurloeDatabaseConnector extends DataAccess {
   val samDAO = mock[HttpSamDAO]
-  override def set(keyValuePairs: UserKeyValuePairs) = Future.failed(new Exception("does not work"))
+  override def set(keyValuePairs: UserKeyValuePairs)(implicit samDao: SamDAO) =
+    Future.failed(new Exception("does not work"))
 
-  override def lookup(userId: String, key: String) = Future.failed(new Exception("does not work"))
+  override def lookup(userId: String, key: String)(implicit samDao: SamDAO) =
+    Future.failed(new Exception("does not work"))
 
-  override def lookup(userId: String) = Future.failed(new Exception("does not work"))
+  override def lookup(userId: String)(implicit samDao: SamDAO) = Future.failed(new Exception("does not work"))
 
-  override def lookup(query: ThurloeQuery) = Future.failed(new Exception("does not work"))
+  override def lookup(query: ThurloeQuery)(implicit samDao: SamDAO) = Future.failed(new Exception("does not work"))
 
   override def delete(userId: String, key: String) = Future.failed(new Exception("does not work"))
 

--- a/src/test/scala/thurloe/database/MockUnhealthyThurloeDatabaseConnector.scala
+++ b/src/test/scala/thurloe/database/MockUnhealthyThurloeDatabaseConnector.scala
@@ -1,10 +1,13 @@
 package thurloe.database
 
+import org.mockito.MockitoSugar.mock
+import thurloe.dataaccess.HttpSamDAO
 import thurloe.service.{ThurloeQuery, UserKeyValuePairs}
 
 import scala.concurrent.Future
 
 case object MockUnhealthyThurloeDatabaseConnector extends DataAccess {
+  val samDAO = mock[HttpSamDAO]
   override def set(keyValuePairs: UserKeyValuePairs) = Future.failed(new Exception("does not work"))
 
   override def lookup(userId: String, key: String) = Future.failed(new Exception("does not work"))

--- a/src/test/scala/thurloe/notification/NotificationMonitorSpec.scala
+++ b/src/test/scala/thurloe/notification/NotificationMonitorSpec.scala
@@ -30,7 +30,7 @@ class NotificationMonitorSpec(_system: ActorSystem)
     with BeforeAndAfterAll {
   def this() = this(ActorSystem("NotificationMonitorSpec"))
 
-  implicit val samDao = mock[HttpSamDAO]
+  val samDao = mock[HttpSamDAO]
 
   override def beforeAll(): Unit =
     super.beforeAll()
@@ -56,7 +56,8 @@ class NotificationMonitorSpec(_system: ActorSystem)
         workerCount,
         sendGridDAO,
         Map("WorkspaceInvitedNotification" -> "valid_notification_id1"),
-        "foo"
+        "foo",
+        samDao
       )
     )
 
@@ -113,7 +114,8 @@ class NotificationMonitorSpec(_system: ActorSystem)
         sendGridDAO,
         Map("WorkspaceRemovedNotification" -> "valid_notification_id1",
             "WorkspaceAddedNotification" -> "valid_notification_id1"),
-        "foo"
+        "foo",
+        samDao
       )
     )
 
@@ -142,7 +144,8 @@ class NotificationMonitorSpec(_system: ActorSystem)
       WorkspaceAddedNotification(WorkbenchUserId(userId), "foo", workspaceName, WorkbenchUserId("a_user_id2"))
 
     Await.result(
-      ThurloeDatabaseConnector.set(UserKeyValuePairs(userId, Seq(KeyValuePair(addedNotification.key, "false")))),
+      ThurloeDatabaseConnector.set(samDao,
+                                   UserKeyValuePairs(userId, Seq(KeyValuePair(addedNotification.key, "false")))),
       Duration.Inf
     )
 
@@ -173,7 +176,8 @@ class NotificationMonitorSpec(_system: ActorSystem)
         sendGridDAO,
         Map("WorkspaceRemovedNotification" -> "valid_notification_id1",
             "WorkspaceAddedNotification" -> "valid_notification_id1"),
-        "foo"
+        "foo",
+        samDao
       )
     )
 
@@ -195,6 +199,7 @@ class NotificationMonitorSpec(_system: ActorSystem)
       WorkspaceAddedNotification(WorkbenchUserId(userId), "foo", workspaceName, WorkbenchUserId("a_user_id2"))
 
     Await.result(ThurloeDatabaseConnector.set(
+                   samDao,
                    UserKeyValuePairs(userId, Seq(KeyValuePair(NotificationMonitor.notificationsOffKey, "true")))
                  ),
                  Duration.Inf)
@@ -225,7 +230,8 @@ class NotificationMonitorSpec(_system: ActorSystem)
         workerCount,
         sendGridDAO,
         Map("WorkspaceRemovedNotification" -> "valid_notification_id1"),
-        "foo"
+        "foo",
+        samDao
       )
     )
 
@@ -246,6 +252,7 @@ class NotificationMonitorSpec(_system: ActorSystem)
 
     Await.result(
       ThurloeDatabaseConnector.set(
+        samDao,
         UserKeyValuePairs(
           userId,
           Seq(
@@ -285,7 +292,8 @@ class NotificationMonitorSpec(_system: ActorSystem)
         workerCount,
         sendGridDAO,
         Map("WorkspaceRemovedNotification" -> "valid_notification_id1"),
-        "foo"
+        "foo",
+        samDao
       )
     )
 
@@ -313,6 +321,7 @@ class NotificationMonitorSpec(_system: ActorSystem)
 
     Await.result(
       ThurloeDatabaseConnector.set(
+        samDao,
         UserKeyValuePairs(userId, Seq(KeyValuePair(s"notifications/SuccessfulSubmissionNotification", "false")))
       ),
       Duration.Inf
@@ -345,7 +354,8 @@ class NotificationMonitorSpec(_system: ActorSystem)
         sendGridDAO,
         Map("WorkspaceRemovedNotification" -> "valid_notification_id1",
             "WorkspaceAddedNotification" -> "valid_notification_id1"),
-        "foo"
+        "foo",
+        samDao
       )
     )
 
@@ -361,6 +371,7 @@ class NotificationMonitorSpec(_system: ActorSystem)
 
     // Make sure notifications are turned on for the test user (notificationsOffKey -> false)
     Await.result(ThurloeDatabaseConnector.set(
+                   samDao,
                    UserKeyValuePairs(userId, Seq(KeyValuePair(NotificationMonitor.notificationsOffKey, "false")))
                  ),
                  Duration.Inf)

--- a/src/test/scala/thurloe/service/FireCloudProtectedServiceSpec.scala
+++ b/src/test/scala/thurloe/service/FireCloudProtectedServiceSpec.scala
@@ -14,7 +14,7 @@ class FireCloudProtectedServiceSpec extends AnyFunSpec with ScalatestRouteTest {
   val userId = "fake"
 
   def protectedServices = new FireCloudProtectedServices {
-    implicit val samDao: SamDAO = mock[SamDAO]
+    val samDao: SamDAO = mock[SamDAO]
     val samUser1 = new sam.model.User()
     samUser1.setId(userId)
     samUser1.setAzureB2CId(userId)

--- a/src/test/scala/thurloe/service/FireCloudProtectedServiceSpec.scala
+++ b/src/test/scala/thurloe/service/FireCloudProtectedServiceSpec.scala
@@ -3,13 +3,24 @@ package thurloe.service
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.mockito.Mockito.when
+import org.mockito.MockitoSugar.mock
 import org.scalatest.funspec.AnyFunSpec
-import thurloe.dataaccess.MockSendGridDAO
+import thurloe.dataaccess.{MockSendGridDAO, SamDAO}
 import thurloe.database.ThurloeDatabaseConnector
+import org.broadinstitute.dsde.workbench.client.sam
 
 class FireCloudProtectedServiceSpec extends AnyFunSpec with ScalatestRouteTest {
+  val userId = "fake"
 
   def protectedServices = new FireCloudProtectedServices {
+    implicit val samDao: SamDAO = mock[SamDAO]
+    val samUser1 = new sam.model.User()
+    samUser1.setId(userId)
+    samUser1.setAzureB2CId(userId)
+    samUser1.setGoogleSubjectId(userId)
+
+    when(samDao.getUserById(userId)).thenReturn(List(samUser1))
     val dataAccess = ThurloeDatabaseConnector
     val sendGridDAO = new MockSendGridDAO
     def actorRefFactory = system
@@ -23,7 +34,7 @@ class FireCloudProtectedServiceSpec extends AnyFunSpec with ScalatestRouteTest {
   describe("The Thurloe Service") {
 
     it("should return a valid response with a correct header") {
-      Get(uriPrefix + "?userId=fake") ~> addHeader(RawHeader(fcHeader, fcId)) ~> routes ~> check {
+      Get(uriPrefix + s"?userId=$userId") ~> addHeader(RawHeader(fcHeader, fcId)) ~> routes ~> check {
         assertResult(StatusCodes.OK) {
           status
         }
@@ -31,7 +42,7 @@ class FireCloudProtectedServiceSpec extends AnyFunSpec with ScalatestRouteTest {
     }
 
     it("should return a BadRequest response that indicates an incorrect header value") {
-      Get(uriPrefix + "?userId=fake") ~> addHeader(RawHeader(fcHeader, "invalid")) ~> routes ~> check {
+      Get(uriPrefix + s"?userId=$userId") ~> addHeader(RawHeader(fcHeader, "invalid")) ~> routes ~> check {
         assert(responseAs[String].contains("Invalid 'X-FireCloud-Id' Header Provided"))
         assertResult(StatusCodes.BadRequest) {
           status
@@ -40,7 +51,7 @@ class FireCloudProtectedServiceSpec extends AnyFunSpec with ScalatestRouteTest {
     }
 
     it("should return a BadRequest response that indicates a missing header") {
-      Get(uriPrefix + "?userId=fake") ~> routes ~> check {
+      Get(uriPrefix + s"?userId=$userId") ~> routes ~> check {
         assert(responseAs[String].contains("Request is missing required HTTP header 'X-FireCloud-Id'"))
         assertResult(StatusCodes.BadRequest) {
           status

--- a/src/test/scala/thurloe/service/ThurloeServiceSpec.scala
+++ b/src/test/scala/thurloe/service/ThurloeServiceSpec.scala
@@ -363,7 +363,8 @@ class ThurloeServiceSpec extends AnyFunSpec with ScalatestRouteTest {
       }
     }
 
-    it("should handle users with differing ids") {
+    it("should handle sam users with differing ids") {
+      // prepare values and mocks
       val userSamId = "samId"
       val userSubjectId = "subjectId"
       val userB2cId = "b2cId"
@@ -396,6 +397,7 @@ class ThurloeServiceSpec extends AnyFunSpec with ScalatestRouteTest {
       val u1k2v2subjectId = UserKeyValuePairs(userSubjectId, Seq(k2v2))
       val u1k2v2SamId = UserKeyValuePairs(userSamId, Seq(k2v2))
 
+      // Create key values for same user with different ids
       Post(uriPrefix, u1k1v1B2cId) ~> thurloeService.keyValuePairRoutes ~> check {
         assertResult("") {
           responseAs[String]
@@ -414,6 +416,7 @@ class ThurloeServiceSpec extends AnyFunSpec with ScalatestRouteTest {
         }
       }
 
+      // Assert that all ids can be used to get the same key value
       Get(s"$uriPrefix/$userSubjectId/$key1") ~> thurloeService.keyValuePairRoutes ~> check {
         assertResult(u1k1v1SubjectId.toKeyValueSeq.head) {
           responseAs[UserKeyValuePair]

--- a/src/test/scala/thurloe/service/ThurloeServiceSpec.scala
+++ b/src/test/scala/thurloe/service/ThurloeServiceSpec.scala
@@ -40,7 +40,7 @@ class ThurloeServiceSpec extends AnyFunSpec with ScalatestRouteTest {
   val u3k3v3 = UserKeyValuePairs("NEVER FOUND", Seq(KeyValuePair("NEvER", "FOUND")))
 
   def thurloeService = new ThurloeService {
-    implicit val samDao: SamDAO = mock[SamDAO]
+    val samDao: SamDAO = mock[SamDAO]
 
     val samUser1 = new sam.model.User()
     val samUser2 = new sam.model.User()
@@ -351,7 +351,7 @@ class ThurloeServiceSpec extends AnyFunSpec with ScalatestRouteTest {
 
     it("should fail with internal server error") {
       val errorThurloe = new ThurloeService {
-        implicit val samDao: SamDAO = mock[HttpSamDAO]
+        val samDao: SamDAO = mock[HttpSamDAO]
         when(samDao.getUserById(user1)).thenReturn(List.empty)
         val dataAccess = MockUnhealthyThurloeDatabaseConnector
         def actorRefFactory = system
@@ -381,7 +381,7 @@ class ThurloeServiceSpec extends AnyFunSpec with ScalatestRouteTest {
       val value2 = "value1"
       val k2v2 = KeyValuePair(key2, value2)
       val thurloeService = new ThurloeService {
-        implicit val samDao: SamDAO = mock[HttpSamDAO]
+        val samDao: SamDAO = mock[HttpSamDAO]
         when(samDao.getUserById(userB2cId)).thenReturn(List(user1))
         when(samDao.getUserById(userSubjectId)).thenReturn(List(user1))
         when(samDao.getUserById(userSamId)).thenReturn(List(user1))

--- a/src/test/scala/thurloe/service/ThurloeServiceSpec.scala
+++ b/src/test/scala/thurloe/service/ThurloeServiceSpec.scala
@@ -482,8 +482,8 @@ class ThurloeServiceSpec extends AnyFunSpec with ScalatestRouteTest {
       user2.setGoogleSubjectId(userSubjectId)
       user2.setAzureB2CId(userB2cId)
 
-      val key1 = "key1"
-      val value1 = "value1"
+      val key1 = "k1"
+      val value1 = "v1"
       val k1v1 = KeyValuePair(key1, value1)
 
       val thurloeService = new ThurloeService {

--- a/src/test/scala/thurloe/service/ThurloeServiceSpec.scala
+++ b/src/test/scala/thurloe/service/ThurloeServiceSpec.scala
@@ -389,8 +389,12 @@ class ThurloeServiceSpec extends AnyFunSpec with ScalatestRouteTest {
       }
 
       val u1k1v1B2cId = UserKeyValuePairs(userB2cId, Seq(k1v1))
+      val u1k1v1SubjectId = UserKeyValuePairs(userSubjectId, Seq(k1v1))
+      val u1k1v1SamId = UserKeyValuePairs(userSamId, Seq(k1v1))
+
       val u1k2v2B2cId = UserKeyValuePairs(userB2cId, Seq(k2v2))
       val u1k2v2subjectId = UserKeyValuePairs(userSubjectId, Seq(k2v2))
+      val u1k2v2SamId = UserKeyValuePairs(userSamId, Seq(k2v2))
 
       Post(uriPrefix, u1k1v1B2cId) ~> thurloeService.keyValuePairRoutes ~> check {
         assertResult("") {
@@ -411,7 +415,7 @@ class ThurloeServiceSpec extends AnyFunSpec with ScalatestRouteTest {
       }
 
       Get(s"$uriPrefix/$userSubjectId/$key1") ~> thurloeService.keyValuePairRoutes ~> check {
-        assertResult(u1k1v1B2cId.toKeyValueSeq.head) {
+        assertResult(u1k1v1SubjectId.toKeyValueSeq.head) {
           responseAs[UserKeyValuePair]
         }
         assertResult(StatusCodes.OK) {
@@ -427,7 +431,7 @@ class ThurloeServiceSpec extends AnyFunSpec with ScalatestRouteTest {
         }
       }
       Get(s"$uriPrefix/$userSamId/$key1") ~> thurloeService.keyValuePairRoutes ~> check {
-        assertResult(u1k1v1B2cId.toKeyValueSeq.head) {
+        assertResult(u1k1v1SamId.toKeyValueSeq.head) {
           responseAs[UserKeyValuePair]
         }
         assertResult(StatusCodes.OK) {
@@ -436,7 +440,7 @@ class ThurloeServiceSpec extends AnyFunSpec with ScalatestRouteTest {
       }
 
       Get(s"$uriPrefix/$userSamId/$key2") ~> thurloeService.keyValuePairRoutes ~> check {
-        assertResult(u1k2v2B2cId.toKeyValueSeq.head) {
+        assertResult(u1k2v2SamId.toKeyValueSeq.head) {
           responseAs[UserKeyValuePair]
         }
         assertResult(StatusCodes.OK) {
@@ -444,7 +448,7 @@ class ThurloeServiceSpec extends AnyFunSpec with ScalatestRouteTest {
         }
       }
       Get(s"$uriPrefix/$userSubjectId/$key2") ~> thurloeService.keyValuePairRoutes ~> check {
-        assertResult(u1k2v2B2cId.toKeyValueSeq.head) {
+        assertResult(u1k2v2subjectId.toKeyValueSeq.head) {
           responseAs[UserKeyValuePair]
         }
         assertResult(StatusCodes.OK) {


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-728

What:
In order to send notifications to azure users we need thurloe to lookup the id it receives for a notification request and look up all other ids for that user via a call to sam. Then thurloe will use those ids to lookup the user in its database since it doesnt know what type of id it will be passed. Eventually we will move to using only sam internal ids.

Thurloe doesnt know what TYPE of id it has so sam needs to accept any type and return all ids on that user.

Why:

We need to support notifications for azure users.

How:

Adding a new sam api call in the database lookup logic. 

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
