### PR TITLE
ID-946 Upgrade logback-classic to fix vulnerability.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ libraryDependencies ++= Seq(
   "org.liquibase" % "liquibase-core" % "4.7.1",
   "org.hsqldb" % "hsqldb" % "2.6.1",
   "com.sendgrid" % "sendgrid-java" % "2.2.2",
-  "ch.qos.logback" % "logback-classic" % "1.2.10",
+  "ch.qos.logback" % "logback-classic" % "1.4.14",
   "org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-4cde1ff",
 //---------- Test libraries -------------------//
   "org.broadinstitute.dsde.workbench" %%  "workbench-google" % workbenchGoogleV % Test classifier "tests",


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-946

The following version in use was found to contain a vulnerability: 1.2.10

Upgradingto a non-vulnerable version of this library will fix this finding. The fixed version of this library is: 1.3.12

This pr also updates logback core since it is a dependency of logback classic.