### PR TITLE
ID-985 Add sentry-logback dependency.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http-spray-json" % "10.2.9",
   "com.google.protobuf" % "protobuf-java" % "4.0.0-rc-2",
   "io.sentry" % "sentry" % "6.9.2",
+  "io.sentry" % "sentry-logback" % "6.9.2",
   "org.broadinstitute.dsde.workbench" %%  "workbench-google" % workbenchGoogleV
     exclude("com.typesafe.akka", "akka-protobuf-v3_2.13")
     exclude("com.google.protobuf", "protobuf-java")

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -31,7 +31,7 @@
     </appender>
 
     <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
-    <appender name="Sentry" class="com.getsentry.raven.logback.SentryAppender">
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>ERROR</level>
         </filter>


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-985

I noticed this in the logs: `Failed to instantiate type com.getsentry.raven.logback.SentryAppender`

In order to work with logback, sentry needs this dependency. It was also being referenced improperly in the logback config.

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
