### PR TITLE
[ID-1063] Add flag to enable sending emails

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -49,6 +49,7 @@ sendgrid {
   apiKey = "dummyApiKey"
   defaultFromAddress = "help@test.firecloud.org"
   defaultFromName = "FireCloud"
+  shouldSendEmails = ${?SHOULD_SEND_EMAILS}
   substitutionChar = "%"
 }
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -37,6 +37,17 @@
         </filter>
     </appender>
 
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
+        <encoder>
+            <pattern>%date [%thread] - 5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="errors" level="ERROR ">
+        <appender-ref ref="STDERR"/>
+    </logger>
+
     <logger name="org.broadinstitute.dsde" level="info" additivity="false">
         <appender-ref ref="file"/>
         <appender-ref ref="console"/>

--- a/src/main/scala/thurloe/dataaccess/SendGridDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/SendGridDAO.scala
@@ -18,14 +18,13 @@ trait SendGridDAO {
   val substitutionChar = sendGridConfig.getString("substitutionChar")
   val defaultFromAddress = sendGridConfig.getString("defaultFromAddress")
   val defaultFromName = sendGridConfig.getString("defaultFromName")
-  val shouldSendEmails = sendGridConfig.getBoolean("shouldSendEmails")
 
   def sendEmail(email: SendGrid.Email): Future[Response]
   def lookupPreferredEmail(userId: WorkbenchUserId): Future[WorkbenchEmail]
   def lookupUserName(userId: WorkbenchUserId): Future[String]
   def lookupUserFirstName(userId: WorkbenchUserId): Future[String]
 
-  def sendNotifications(notifications: List[Notification]): Future[List[Option[Response]]] =
+  def sendNotifications(notifications: List[Notification]): Future[List[Response]] =
     Future.sequence(notifications.map { notification =>
       val toAddressFuture = notification.userEmail
         .map(Future.successful)
@@ -59,25 +58,21 @@ trait SendGridDAO {
         case None         => Future.successful(Map.empty)
       }
 
-      if (shouldSendEmails) {
-        for {
-          toAddress <- toAddressFuture
-          replyTos <- replyTosFuture
-          emailSubstitutions <- emailSubstitutionsFuture
-          nameSubstitution <- nameSubstitutionsFuture
-          recipientFirstNameSubstitution <- recipientFirstNameSubstitutionFuture
-          response <- sendEmail(
-            createEmail(
-              toAddress,
-              replyTos,
-              notification.notificationId,
-              notification.substitutions ++ emailSubstitutions ++ nameSubstitution ++ recipientFirstNameSubstitution
-            )
+      for {
+        toAddress <- toAddressFuture
+        replyTos <- replyTosFuture
+        emailSubstitutions <- emailSubstitutionsFuture
+        nameSubstitution <- nameSubstitutionsFuture
+        recipientFirstNameSubstitution <- recipientFirstNameSubstitutionFuture
+        response <- sendEmail(
+          createEmail(
+            toAddress,
+            replyTos,
+            notification.notificationId,
+            notification.substitutions ++ emailSubstitutions ++ nameSubstitution ++ recipientFirstNameSubstitution
           )
-        } yield Option(response)
-      } else {
-        Future.successful(None)
-      }
+        )
+      } yield response
     })
 
   /*

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -4,6 +4,7 @@ import akka.actor.SupervisorStrategy.{Escalate, Stop}
 import akka.actor._
 import akka.pattern._
 import com.sendgrid.SendGrid.Response
+import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO.PubSubMessage
@@ -147,6 +148,10 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
     extends Actor
     with LazyLogging {
 
+  val configFile = ConfigFactory.load()
+  val sendGridConfig = configFile.getConfig("sendgrid")
+  val shouldSendEmails = sendGridConfig.getBoolean("shouldSendEmails")
+
   self ! StartMonitorPass
 
   // fail safe in case this actor is idle too long but not too fast (1 second lower limit)
@@ -191,7 +196,7 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
     val notification = message.contents.parseJson.convertTo[Notification]
     lookupShouldNotify(notification) flatMap { shouldNotify =>
       if (shouldNotify) {
-        sendGridDAO.sendNotifications(List(toThurloeNotification(notification))).map(_.head) recoverWith {
+        sendGridDAO.sendNotifications(List(toThurloeNotification(notification))).map(_.headOption) recoverWith {
           case e: KeyNotFoundException =>
             logger.info(s"Unable to send notification due to missing key: ${e.getMessage}")
             Future.successful(None)
@@ -203,7 +208,9 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
     } map { responseOption => (responseOption, message) }
   }
 
-  def lookupShouldNotify(notification: Notification): Future[Boolean] =
+  def lookupShouldNotify(notification: Notification): Future[Boolean] = {
+    // shouldSendEmails is a per-environment flag to turn off all email sending
+    if (!shouldSendEmails) return Future.successful(false)
     notification match {
       //For workspace notifications, there are three tiers of preferences to check:
       // 1. has the user disabled *all* notifications for their account?
@@ -229,6 +236,7 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
         }
       case _ => Future.successful(true)
     }
+  }
 
   def booleanLookup(userId: WorkbenchUserId, key: String, defaultValue: Boolean): Future[Boolean] =
     dataAccess.lookup(samDao, userId.value, key).map(kvp => kvp.keyValuePair.value.toBoolean).recover {

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -191,7 +191,7 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
     val notification = message.contents.parseJson.convertTo[Notification]
     lookupShouldNotify(notification) flatMap { shouldNotify =>
       if (shouldNotify) {
-        sendGridDAO.sendNotifications(List(toThurloeNotification(notification))).map(_.headOption) recoverWith {
+        sendGridDAO.sendNotifications(List(toThurloeNotification(notification))).map(_.head) recoverWith {
           case e: KeyNotFoundException =>
             logger.info(s"Unable to send notification due to missing key: ${e.getMessage}")
             Future.successful(None)

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,63 @@
+akka.http {
+
+  server {
+    # The default value of the `Server` header to produce if no
+    # explicit `Server`-header was included in a response.
+    # If this value is the empty string and no header was included in
+    # the request, no `Server` header will be rendered at all.
+    server-header = ""
+  }
+}
+
+swagger {
+  docsPath = "swagger/thurloe.yaml"
+  uiVersion = "2.1.1"
+}
+
+sam {
+  samBaseUrl = ${?SAM_BASE_URL}
+  timeout=60s
+}
+
+database {
+  config = hsqldb
+
+  hsqldb {
+    db {
+      url = "jdbc:hsqldb:mem:memdb;shutdown=false;hsqldb.tx=mvcc"
+      driver = "org.hsqldb.jdbcDriver"
+    }
+    driver = "slick.driver.HsqldbDriver$"
+  }
+
+  mysql {
+    db {
+      url = "jdbc:mysql://localhost/thurloe_test"
+      user = "travis"
+      password = ""
+      driver = "com.mysql.jdbc.Driver"
+    }
+    driver = "slick.driver.MySQLDriver$"
+  }
+}
+
+crypto {
+  key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+}
+
+sendgrid {
+  apiKey = "dummyApiKey"
+  defaultFromAddress = "help@test.firecloud.org"
+  defaultFromName = "FireCloud"
+  shouldSendEmails = true
+  substitutionChar = "%"
+}
+
+fireCloud {
+  id = "12345"
+}
+
+liquibase {
+  changelog = "org/broadinstitute/dsde/thurloe/liquibase/changelog.xml"
+  initWithLiquibase = true
+}


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-1063

Sendgrid is only setup with credentials in prod and in staging a bunch of errors get thrown. We want to add a per-environment flag to enable/disable email sending.

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
