### PR TITLE
ID-1066 Resolve conflicting userid-key records.

### DIFF
--- a/.github/workflows/thurloe-build-tag-publish.yml
+++ b/.github/workflows/thurloe-build-tag-publish.yml
@@ -88,6 +88,7 @@ jobs:
       id-token: 'write'
 
   set-version-in-dev:
+    if: ${{ github.ref_name == 'develop' }}
     # Put new thurloe version in Broad dev environment
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
     needs: [thurloe-build-tag-publish-job, report-to-sherlock]

--- a/.github/workflows/thurloe-build-tag-publish.yml
+++ b/.github/workflows/thurloe-build-tag-publish.yml
@@ -88,7 +88,7 @@ jobs:
       id-token: 'write'
 
   set-version-in-dev:
-    if: ${{ github.ref_name == 'develop' }}
+    if: ${{ github.event_name != 'pull_request' }}
     # Put new thurloe version in Broad dev environment
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
     needs: [thurloe-build-tag-publish-job, report-to-sherlock]

--- a/src/main/scala/thurloe/database/DataAccess.scala
+++ b/src/main/scala/thurloe/database/DataAccess.scala
@@ -7,7 +7,7 @@ import thurloe.service.{ThurloeQuery, UserKeyValuePair, UserKeyValuePairs}
 import scala.concurrent.Future
 
 trait DataAccess {
-  def set(samDao: SamDAO, keyValuePairs: UserKeyValuePairs): Future[DatabaseOperation]
+  def set(keyValuePairs: UserKeyValuePairs): Future[DatabaseOperation]
   def lookup(samDao: SamDAO, userId: String, key: String): Future[UserKeyValuePair]
   def lookup(samDao: SamDAO, userId: String): Future[UserKeyValuePairs]
   def lookup(samDao: SamDAO, query: ThurloeQuery): Future[Seq[UserKeyValuePair]]

--- a/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
+++ b/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
@@ -157,10 +157,9 @@ case object ThurloeDatabaseConnector extends DataAccess with LazyLogging {
       val value2 = result2.userKeyValuePair.keyValuePair.value
 
       val isRegistrationComplete = result1.userKeyValuePair.keyValuePair.key == "isRegistrationComplete"
-      val isValue1Greater = value1.toInt > value2.toInt
 
       if (isRegistrationComplete) {
-        if (isValue1Greater) result1 else result2
+        if (value1.toInt > value2.toInt) result1 else result2
       } else if (value1 == value2) {
         result1
       } else if (value1 != "N/A") {

--- a/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
+++ b/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
@@ -165,6 +165,7 @@ case object ThurloeDatabaseConnector extends DataAccess with LazyLogging {
       } else if (value1 != "N/A") {
         result1
       } else {
+        // Thurloe doesnt store timestamps with key value pairs, so we assume that the last record is the most recent
         result2
       }
     }

--- a/src/main/scala/thurloe/service/ThurloeService.scala
+++ b/src/main/scala/thurloe/service/ThurloeService.scala
@@ -93,7 +93,7 @@ trait ThurloeService extends LazyLogging {
     path(ThurloePrefix) {
       post {
         entity(as[UserKeyValuePairs]) { keyValuePairs =>
-          onComplete(dataAccess.set(samDao, keyValuePairs)) {
+          onComplete(dataAccess.set(keyValuePairs)) {
             case Success(setKeyResponse) =>
               complete(statusCode(setKeyResponse), HttpEntity(ContentTypes.`application/json`, ""))
             case Failure(e) =>

--- a/src/test/scala/thurloe/database/MockThurloeDatabaseConnector.scala
+++ b/src/test/scala/thurloe/database/MockThurloeDatabaseConnector.scala
@@ -15,7 +15,7 @@ case object MockThurloeDatabaseConnector extends DataAccess {
   // By default return no users
   when(samDAO.getUserById(any[String])).thenReturn(List.empty)
 
-  override def set(samDao: SamDAO, keyValuePairs: UserKeyValuePairs): Future[DatabaseOperation] = ???
+  override def set(keyValuePairs: UserKeyValuePairs): Future[DatabaseOperation] = ???
 
   override def lookup(samDao: SamDAO, userId: String, key: String): Future[UserKeyValuePair] = ???
 

--- a/src/test/scala/thurloe/database/MockUnhealthyThurloeDatabaseConnector.scala
+++ b/src/test/scala/thurloe/database/MockUnhealthyThurloeDatabaseConnector.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
 
 case object MockUnhealthyThurloeDatabaseConnector extends DataAccess {
   val samDAO = mock[HttpSamDAO]
-  override def set(samDao: SamDAO, keyValuePairs: UserKeyValuePairs): Future[DatabaseOperation] =
+  override def set(keyValuePairs: UserKeyValuePairs): Future[DatabaseOperation] =
     Future.failed(new Exception("does not work"))
 
   override def lookup(samDao: SamDAO, userId: String, key: String): Future[UserKeyValuePair] =

--- a/src/test/scala/thurloe/notification/NotificationMonitorSpec.scala
+++ b/src/test/scala/thurloe/notification/NotificationMonitorSpec.scala
@@ -150,8 +150,7 @@ class NotificationMonitorSpec(_system: ActorSystem)
       WorkspaceAddedNotification(WorkbenchUserId(userId), "foo", workspaceName, WorkbenchUserId("a_user_id2"))
 
     Await.result(
-      ThurloeDatabaseConnector.set(samDao,
-                                   UserKeyValuePairs(userId, Seq(KeyValuePair(addedNotification.key, "false")))),
+      ThurloeDatabaseConnector.set(UserKeyValuePairs(userId, Seq(KeyValuePair(addedNotification.key, "false")))),
       Duration.Inf
     )
 
@@ -210,7 +209,6 @@ class NotificationMonitorSpec(_system: ActorSystem)
       WorkspaceAddedNotification(WorkbenchUserId(userId), "foo", workspaceName, WorkbenchUserId("a_user_id2"))
 
     Await.result(ThurloeDatabaseConnector.set(
-                   samDao,
                    UserKeyValuePairs(userId, Seq(KeyValuePair(NotificationMonitor.notificationsOffKey, "true")))
                  ),
                  Duration.Inf)
@@ -268,7 +266,6 @@ class NotificationMonitorSpec(_system: ActorSystem)
 
     Await.result(
       ThurloeDatabaseConnector.set(
-        samDao,
         UserKeyValuePairs(
           userId,
           Seq(
@@ -342,7 +339,6 @@ class NotificationMonitorSpec(_system: ActorSystem)
 
     Await.result(
       ThurloeDatabaseConnector.set(
-        samDao,
         UserKeyValuePairs(userId, Seq(KeyValuePair(s"notifications/SuccessfulSubmissionNotification", "false")))
       ),
       Duration.Inf
@@ -397,7 +393,6 @@ class NotificationMonitorSpec(_system: ActorSystem)
 
     // Make sure notifications are turned on for the test user (notificationsOffKey -> false)
     Await.result(ThurloeDatabaseConnector.set(
-                   samDao,
                    UserKeyValuePairs(userId, Seq(KeyValuePair(NotificationMonitor.notificationsOffKey, "false")))
                  ),
                  Duration.Inf)


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-1066

What:

This pr is to address [this sentry issue](https://broad-institute.sentry.io/issues/4496738057/events/5640864b944c4468ac01418148ea46d4/?project=4504295627882496&query=is%3Aunresolved&referrer=previous-event&statsPeriod=30d&stream_index=1). It adds code to resolve collisions between userid-key combinations when a user has the same key stored under multiple types of ids.

Why:

When the switchover to b2c happened we overlooked the impact it would have on storing and retrieving thurloe records. Depending on the user they may have their thurloe record retrieved via their subject id, b2cid, or samid (i am actually not really positive the samid lookup ever happens). Users could also have the same record stored under various types of ids that they have. We have noticed a few users hitting this problem (i believe during registration), and currently the code just throws an error.

How:

 Instead of throwing an error we go through some conditional logic to make our best guess at what to return. 

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
