### PR TITLE
ID-1137 Fix build-tag-publish ci to not deploy pr's to dev.

### DIFF
--- a/.github/workflows/thurloe-build-tag-publish.yml
+++ b/.github/workflows/thurloe-build-tag-publish.yml
@@ -88,6 +88,7 @@ jobs:
       id-token: 'write'
 
   set-version-in-dev:
+    if: ${{ github.ref_name == 'develop' }}
     # Put new thurloe version in Broad dev environment
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
     needs: [thurloe-build-tag-publish-job, report-to-sherlock]

--- a/.github/workflows/thurloe-build-tag-publish.yml
+++ b/.github/workflows/thurloe-build-tag-publish.yml
@@ -88,7 +88,7 @@ jobs:
       id-token: 'write'
 
   set-version-in-dev:
-    if: ${{ github.ref_name == 'develop' }}
+    if: ${{ github.event_name != 'pull_request' }}
     # Put new thurloe version in Broad dev environment
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
     needs: [thurloe-build-tag-publish-job, report-to-sherlock]


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-1137

What:

This pr ensures that CI deploys to dev ONLY when running against the develop branch.

Why:

We dont want pr's deployed to dev because they will then be promoted to staging and prod via the monolith deploy process. 

How:

Only deploy to dev if the CI is running NOT on a PR.

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
