### PR TITLE
[TOAZ-362] Use MI to call SAM and add flag to disable notifications

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,8 @@ libraryDependencies ++= Seq(
   "com.sendgrid" % "sendgrid-java" % "2.2.2",
   "ch.qos.logback" % "logback-classic" % "1.4.14",
   "org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-4cde1ff",
+  "com.azure" % "azure-identity" % "1.12.2",
+  "com.azure" % "azure-core-management" % "1.15.0",
 //---------- Test libraries -------------------//
   "org.broadinstitute.dsde.workbench" %%  "workbench-google" % workbenchGoogleV % Test classifier "tests",
   "com.typesafe.akka" %% "akka-testkit" % akkaV % Test,

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -69,3 +69,7 @@ azureHosting {
   azureEnvironment = ${?AZURE_ENVIRONMENT}
   tokenScope = ${?AZURE_TOKEN_SCOPE}
 }
+
+app {
+    enableNotifications = ${?ENABLE_NOTIFICATIONS}
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -61,3 +61,11 @@ liquibase {
   changelog = "org/broadinstitute/dsde/thurloe/liquibase/changelog.xml"
   initWithLiquibase = true
 }
+
+azureHosting {
+  # Set to true to enable Azure hosting, if not set or set to false, Gcp hosting will be used
+  enabled = ${AZURE_HOSTING_ENABLED}
+  # AZURE or AZURE_GOV, default is AZURE
+  azureEnvironment = ${AZURE_ENVIRONMENT}
+  tokenScope = ${AZURE_TOKEN_SCOPE}
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -64,8 +64,8 @@ liquibase {
 
 azureHosting {
   # Set to true to enable Azure hosting, if not set or set to false, Gcp hosting will be used
-  enabled = ${AZURE_HOSTING_ENABLED}
+  enabled = ${?AZURE_HOSTING_ENABLED}
   # AZURE or AZURE_GOV, default is AZURE
-  azureEnvironment = ${AZURE_ENVIRONMENT}
-  tokenScope = ${AZURE_TOKEN_SCOPE}
+  azureEnvironment = ${?AZURE_ENVIRONMENT}
+  tokenScope = ${?AZURE_TOKEN_SCOPE}
 }

--- a/src/main/scala/thurloe/Main.scala
+++ b/src/main/scala/thurloe/Main.scala
@@ -4,17 +4,11 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import com.typesafe.config.ConfigFactory
 import io.sentry.{Sentry, SentryOptions}
-import org.broadinstitute.dsde.workbench.google.{GoogleCredentialModes, HttpGooglePubSubDAO}
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.util.toScalaDuration
+import thurloe.dataaccess.HttpSamDAO
 import thurloe.dataaccess.auth.CloudServiceAuthTokenProvider
-import thurloe.dataaccess.{HttpSamDAO, HttpSendGridDAO}
-import thurloe.notification.NotificationMonitorSupervisor
 import thurloe.service.ThurloeServiceActor
 
-import java.io.File
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.jdk.CollectionConverters._
 
 object Main extends App {
   val sentryDsn = sys.env.get("SENTRY_DSN")
@@ -35,36 +29,36 @@ object Main extends App {
 
   val samDao = new HttpSamDAO(config, cloudAuthProvider)
 
-  val pem =
-    GoogleCredentialModes.Pem(WorkbenchEmail(gcsConfig.getString("clientEmail")),
-                              new File(gcsConfig.getString("pathToPem")))
-  val pubSubDAO = new HttpGooglePubSubDAO(
-    gcsConfig.getString("appName"),
-    pem,
-    "thurloe",
-    gcsConfig.getString("serviceProject")
-  )
+//  val pem =
+//    GoogleCredentialModes.Pem(WorkbenchEmail(gcsConfig.getString("clientEmail")),
+//                              new File(gcsConfig.getString("pathToPem")))
+//  val pubSubDAO = new HttpGooglePubSubDAO(
+//    gcsConfig.getString("appName"),
+//    pem,
+//    "thurloe",
+//    gcsConfig.getString("serviceProject")
+//  )
 
-  private val httpSendGridDAO = new HttpSendGridDAO(samDao)
-  system.actorOf(
-    NotificationMonitorSupervisor.props(
-      toScalaDuration(gcsConfig.getDuration("notificationMonitor.pollInterval")),
-      toScalaDuration(gcsConfig.getDuration("notificationMonitor.pollIntervalJitter")),
-      pubSubDAO,
-      gcsConfig.getString("notificationMonitor.topicName"),
-      gcsConfig.getString("notificationMonitor.subscriptionName"),
-      gcsConfig.getInt("notificationMonitor.workerCount"),
-      httpSendGridDAO,
-      config
-        .getConfig("notification.templateIds")
-        .entrySet()
-        .asScala
-        .map(entry => entry.getKey -> entry.getValue.unwrapped().toString)
-        .toMap,
-      config.getString("notification.fireCloudPortalUrl"),
-      samDao
-    )
-  )
+//  private val httpSendGridDAO = new HttpSendGridDAO(samDao)
+//  system.actorOf(
+//    NotificationMonitorSupervisor.props(
+//      toScalaDuration(gcsConfig.getDuration("notificationMonitor.pollInterval")),
+//      toScalaDuration(gcsConfig.getDuration("notificationMonitor.pollIntervalJitter")),
+//      pubSubDAO,
+//      gcsConfig.getString("notificationMonitor.topicName"),
+//      gcsConfig.getString("notificationMonitor.subscriptionName"),
+//      gcsConfig.getInt("notificationMonitor.workerCount"),
+//      httpSendGridDAO,
+//      config
+//        .getConfig("notification.templateIds")
+//        .entrySet()
+//        .asScala
+//        .map(entry => entry.getKey -> entry.getValue.unwrapped().toString)
+//        .toMap,
+//      config.getString("notification.fireCloudPortalUrl"),
+//      samDao
+//    )
+//  )
 
   val routes = new ThurloeServiceActor(samDao)
 

--- a/src/main/scala/thurloe/Main.scala
+++ b/src/main/scala/thurloe/Main.scala
@@ -2,13 +2,19 @@ package thurloe
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import io.sentry.{Sentry, SentryOptions}
-import thurloe.dataaccess.HttpSamDAO
+import org.broadinstitute.dsde.workbench.google.{GoogleCredentialModes, HttpGooglePubSubDAO}
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.util.toScalaDuration
+import thurloe.dataaccess.{HttpSamDAO, HttpSendGridDAO}
 import thurloe.dataaccess.auth.CloudServiceAuthTokenProvider
+import thurloe.notification.NotificationMonitorSupervisor
 import thurloe.service.ThurloeServiceActor
 
+import java.io.File
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 object Main extends App {
   val sentryDsn = sys.env.get("SENTRY_DSN")
@@ -20,45 +26,17 @@ object Main extends App {
   }
 
   // We need an ActorSystem to host our application in
-  implicit val system = ActorSystem("thurloe")
+  implicit val system: ActorSystem = ActorSystem("thurloe")
 
   val config = ConfigFactory.load()
-  val gcsConfig = config.getConfig("gcs")
 
   private val cloudAuthProvider = CloudServiceAuthTokenProvider.createProvider(config)
 
   val samDao = new HttpSamDAO(config, cloudAuthProvider)
 
-//  val pem =
-//    GoogleCredentialModes.Pem(WorkbenchEmail(gcsConfig.getString("clientEmail")),
-//                              new File(gcsConfig.getString("pathToPem")))
-//  val pubSubDAO = new HttpGooglePubSubDAO(
-//    gcsConfig.getString("appName"),
-//    pem,
-//    "thurloe",
-//    gcsConfig.getString("serviceProject")
-//  )
-
-//  private val httpSendGridDAO = new HttpSendGridDAO(samDao)
-//  system.actorOf(
-//    NotificationMonitorSupervisor.props(
-//      toScalaDuration(gcsConfig.getDuration("notificationMonitor.pollInterval")),
-//      toScalaDuration(gcsConfig.getDuration("notificationMonitor.pollIntervalJitter")),
-//      pubSubDAO,
-//      gcsConfig.getString("notificationMonitor.topicName"),
-//      gcsConfig.getString("notificationMonitor.subscriptionName"),
-//      gcsConfig.getInt("notificationMonitor.workerCount"),
-//      httpSendGridDAO,
-//      config
-//        .getConfig("notification.templateIds")
-//        .entrySet()
-//        .asScala
-//        .map(entry => entry.getKey -> entry.getValue.unwrapped().toString)
-//        .toMap,
-//      config.getString("notification.fireCloudPortalUrl"),
-//      samDao
-//    )
-//  )
+  if (isNotificationsEnabled(config)) {
+    startNotificationsMonitor(config, samDao)
+  }
 
   val routes = new ThurloeServiceActor(samDao)
 
@@ -72,4 +50,47 @@ object Main extends App {
     _ <- binding.whenTerminated
     _ <- system.terminate()
   } yield ()
+
+  private def startNotificationsMonitor(config: Config, httpSamDAO: HttpSamDAO) = {
+    val gcsConfig = config.getConfig("gcs")
+
+    val pem =
+      GoogleCredentialModes.Pem(WorkbenchEmail(gcsConfig.getString("clientEmail")),
+                                new File(gcsConfig.getString("pathToPem")))
+    val pubSubDAO = new HttpGooglePubSubDAO(
+      gcsConfig.getString("appName"),
+      pem,
+      "thurloe",
+      gcsConfig.getString("serviceProject")
+    )
+
+    val httpSendGridDAO = new HttpSendGridDAO(httpSamDAO)
+    system.actorOf(
+      NotificationMonitorSupervisor.props(
+        toScalaDuration(gcsConfig.getDuration("notificationMonitor.pollInterval")),
+        toScalaDuration(gcsConfig.getDuration("notificationMonitor.pollIntervalJitter")),
+        pubSubDAO,
+        gcsConfig.getString("notificationMonitor.topicName"),
+        gcsConfig.getString("notificationMonitor.subscriptionName"),
+        gcsConfig.getInt("notificationMonitor.workerCount"),
+        httpSendGridDAO,
+        config
+          .getConfig("notification.templateIds")
+          .entrySet()
+          .asScala
+          .map(entry => entry.getKey -> entry.getValue.unwrapped().toString)
+          .toMap,
+        config.getString("notification.fireCloudPortalUrl"),
+        samDao
+      )
+    )
+  }
+
+  private def isNotificationsEnabled(config: Config): Boolean =
+    if (config.hasPath("app.enableNotifications")) {
+      config.getBoolean("app.enableNotifications")
+    } else {
+      // notifications are enabled by default
+      true
+    }
 }

--- a/src/main/scala/thurloe/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/HttpSamDAO.scala
@@ -6,20 +6,19 @@ import okhttp3.Protocol
 import org.broadinstitute.dsde.workbench.client.sam
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient
 import org.broadinstitute.dsde.workbench.client.sam.api.AdminApi
-import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes
+import thurloe.dataaccess.auth.CloudServiceAuthTokenProvider
 
 import scala.jdk.CollectionConverters._
 import scala.jdk.DurationConverters._
 
-class HttpSamDAO(config: Config, credentials: GoogleCredentialModes.Pem) extends SamDAO with LazyLogging {
+class HttpSamDAO(config: Config, cloudServiceAuthTokenProvider: CloudServiceAuthTokenProvider)
+    extends SamDAO
+    with LazyLogging {
 
-  val samConfig = config.getConfig("sam")
+  private val samConfig = config.getConfig("sam")
 
   private val samServiceURL = samConfig.getString("samBaseUrl")
   private val timeout = samConfig.getDuration("timeout").toScala
-
-  val USERINFO_EMAIL = "https://www.googleapis.com/auth/userinfo.email"
-  val USERINFO_PROFILE = "https://www.googleapis.com/auth/userinfo.profile"
 
   private def getApiClient = {
     val okHttpClient = new ApiClient().getHttpClient
@@ -30,16 +29,7 @@ class HttpSamDAO(config: Config, credentials: GoogleCredentialModes.Pem) extends
     val samApiClient = new ApiClient(okHttpClientBuilder.protocols(Seq(Protocol.HTTP_1_1).asJava).build())
     samApiClient.setBasePath(samServiceURL)
 
-    //Set credentials
-    val scopes = List(USERINFO_EMAIL, USERINFO_PROFILE)
-    val saPemCredentials = credentials.toGoogleCredential(scopes)
-    val expiresInSeconds = Option(saPemCredentials.getExpiresInSeconds).map(_.longValue()).getOrElse(0L)
-    val token = if (expiresInSeconds < 60 * 5) {
-      saPemCredentials.refreshToken()
-      saPemCredentials.getAccessToken
-    } else {
-      saPemCredentials.getAccessToken
-    }
+    val token: String = cloudServiceAuthTokenProvider.getAccessToken
     samApiClient.setAccessToken(token)
     samApiClient
   }
@@ -54,5 +44,4 @@ class HttpSamDAO(config: Config, credentials: GoogleCredentialModes.Pem) extends
         logger.warn(s"Sam user not found: $userId", e)
         List.empty
     }
-
 }

--- a/src/main/scala/thurloe/dataaccess/auth/AzureAuthTokenProvider.scala
+++ b/src/main/scala/thurloe/dataaccess/auth/AzureAuthTokenProvider.scala
@@ -1,0 +1,54 @@
+package thurloe.dataaccess.auth
+
+import com.azure.core.credential.TokenRequestContext
+import com.azure.identity.DefaultAzureCredentialBuilder
+import com.typesafe.config.Config
+import com.azure.core.management.AzureEnvironment
+
+import java.time.Duration
+
+class AzureAuthTokenProvider(azureConfig: Config) extends CloudServiceAuthTokenProvider {
+
+  private val azureEnvironment = azureConfig.getString("azureEnvironment")
+  private val tokenScope = azureConfig.getString("tokenScope")
+  private val TOKEN_ACQUISITION_TIMEOUT = 30L
+
+  private val credentialBuilder: DefaultAzureCredentialBuilder =
+    new DefaultAzureCredentialBuilder()
+      .authorityHost(
+        AzureEnvironmentConverter
+          .fromString(azureEnvironment)
+          .getActiveDirectoryEndpoint
+      )
+
+  private val tokenRequestContext: TokenRequestContext = {
+    val trc = new TokenRequestContext()
+    trc.addScopes(tokenScope)
+    trc
+  }
+
+  override def getAccessToken: String = {
+    // The desired client id can be set using the env variable AZURE_CLIENT_ID.
+    // If not set, the client ID of the system assigned managed identity will be used.
+    val credentials = credentialBuilder
+      .build()
+
+    val token = credentials
+      .getToken(tokenRequestContext)
+      .block(Duration.ofSeconds(TOKEN_ACQUISITION_TIMEOUT))
+
+    token.getToken
+  }
+}
+
+object AzureEnvironmentConverter {
+  val Azure: String = "AZURE"
+  val AzureGov: String = "AZURE_GOV"
+
+  def fromString(s: String): AzureEnvironment = s match {
+    case AzureGov => AzureEnvironment.AZURE_US_GOVERNMENT
+    // a bit redundant, but I want to have a explicit case for Azure for clarity, even though it's the default
+    case Azure => AzureEnvironment.AZURE
+    case _     => AzureEnvironment.AZURE
+  }
+}

--- a/src/main/scala/thurloe/dataaccess/auth/CloudServiceAuthTokenProvider.scala
+++ b/src/main/scala/thurloe/dataaccess/auth/CloudServiceAuthTokenProvider.scala
@@ -17,10 +17,8 @@ trait CloudServiceAuthTokenProvider {
  * Factory for creating a CloudServiceAuthTokenProvider.
  */
 object CloudServiceAuthTokenProvider {
-  def createProvider(config: Config): CloudServiceAuthTokenProvider = {
-    val azureHostingEnabled = isAzureHostingEnabled(config)
-
-    if (azureHostingEnabled) {
+  def createProvider(config: Config): CloudServiceAuthTokenProvider =
+    if (isAzureHostingEnabled(config)) {
       new AzureAuthTokenProvider(config.getConfig("azureHosting"))
     } else {
       val gcsConfig = config.getConfig("gcs")
@@ -30,7 +28,6 @@ object CloudServiceAuthTokenProvider {
 
       new GcpAuthTokenProvider(pem)
     }
-  }
 
   def isAzureHostingEnabled(config: Config): Boolean =
     if (config.hasPath("azureHosting.enabled")) {

--- a/src/main/scala/thurloe/dataaccess/auth/CloudServiceAuthTokenProvider.scala
+++ b/src/main/scala/thurloe/dataaccess/auth/CloudServiceAuthTokenProvider.scala
@@ -1,0 +1,41 @@
+package thurloe.dataaccess.auth
+
+import com.typesafe.config.Config
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+
+import java.io.File
+
+/***
+ * Provides an access token for a cloud service.
+ */
+trait CloudServiceAuthTokenProvider {
+  def getAccessToken: String
+}
+
+/***
+ * Factory for creating a CloudServiceAuthTokenProvider.
+ */
+object CloudServiceAuthTokenProvider {
+  def createProvider(config: Config): CloudServiceAuthTokenProvider = {
+    val azureHostingEnabled = isAzureHostingEnabled(config)
+
+    if (azureHostingEnabled) {
+      new AzureAuthTokenProvider(config.getConfig("azureHosting"))
+    } else {
+      val gcsConfig = config.getConfig("gcs")
+      val pem =
+        GoogleCredentialModes.Pem(WorkbenchEmail(gcsConfig.getString("clientEmail")),
+                                  new File(gcsConfig.getString("pathToPem")))
+
+      new GcpAuthTokenProvider(pem)
+    }
+  }
+
+  def isAzureHostingEnabled(config: Config): Boolean =
+    if (config.hasPath("azureHosting.enabled")) {
+      config.getBoolean("azureHosting.enabled")
+    } else {
+      false
+    }
+}

--- a/src/main/scala/thurloe/dataaccess/auth/GcpAuthTokenProvider.scala
+++ b/src/main/scala/thurloe/dataaccess/auth/GcpAuthTokenProvider.scala
@@ -1,0 +1,22 @@
+package thurloe.dataaccess.auth
+
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes
+
+class GcpAuthTokenProvider(credentials: GoogleCredentialModes.Pem) extends CloudServiceAuthTokenProvider {
+  val USERINFO_EMAIL = "https://www.googleapis.com/auth/userinfo.email"
+  val USERINFO_PROFILE = "https://www.googleapis.com/auth/userinfo.profile"
+
+  override def getAccessToken: String = {
+
+    val scopes = List(USERINFO_EMAIL, USERINFO_PROFILE)
+    val saPemCredentials = credentials.toGoogleCredential(scopes)
+    val expiresInSeconds = Option(saPemCredentials.getExpiresInSeconds).map(_.longValue()).getOrElse(0L)
+    val token = if (expiresInSeconds < 60 * 5) {
+      saPemCredentials.refreshToken()
+      saPemCredentials.getAccessToken
+    } else {
+      saPemCredentials.getAccessToken
+    }
+    token
+  }
+}

--- a/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
+++ b/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
@@ -74,13 +74,7 @@ case object ThurloeDatabaseConnector extends DataAccess with LazyLogging {
     val results = samDao.getUserById(userId)
 
     val samUser = if (results.isEmpty) {
-      val dummySamUser = new sam.model.User()
-      dummySamUser.setGoogleSubjectId(userId)
-      dummySamUser.setAzureB2CId(userId)
-      dummySamUser.setId(userId)
-
-      Future.successful(dummySamUser)
-      //Future.failed(new KeyNotFoundException(userId, "n/a"))
+      Future.failed(new KeyNotFoundException(userId, "n/a"))
     } else if (results.size == 1) {
       // If we get exactly one result we have found the user we want.
       Future.successful(results.head)

--- a/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
+++ b/src/main/scala/thurloe/database/ThurloeDatabaseConnector.scala
@@ -74,7 +74,13 @@ case object ThurloeDatabaseConnector extends DataAccess with LazyLogging {
     val results = samDao.getUserById(userId)
 
     val samUser = if (results.isEmpty) {
-      Future.failed(new KeyNotFoundException(userId, "n/a"))
+      val dummySamUser = new sam.model.User()
+      dummySamUser.setGoogleSubjectId(userId)
+      dummySamUser.setAzureB2CId(userId)
+      dummySamUser.setId(userId)
+
+      Future.successful(dummySamUser)
+      //Future.failed(new KeyNotFoundException(userId, "n/a"))
     } else if (results.size == 1) {
       // If we get exactly one result we have found the user we want.
       Future.successful(results.head)


### PR DESCRIPTION
In this PR:
- Added `CloudServiceAuthTokenProvider` with implementations for GCP and Azure. This allows the use MI identity when calling SAM when Thurloe is hosted on Azure.
- Added a new and optional flag that disables notifications. 