### PR TITLE
DC-958: Add notification for snapshot ready

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
     exclude("org.bouncycastle", "bcprov-ext-jdk15on")
     exclude("org.bouncycastle", "bcutil-jdk15on")
     exclude("org.bouncycastle", "bcpkix-jdk15on"),
-  "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.6-1404496"
+  "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.7-9254729"
     exclude("com.typesafe.akka", "akka-protobuf-v3_2.13")
     exclude("com.google.protobuf", "protobuf-java"),
   "com.typesafe.akka" %% "akka-http" % akkaHttpV,

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
     exclude("org.bouncycastle", "bcprov-ext-jdk15on")
     exclude("org.bouncycastle", "bcutil-jdk15on")
     exclude("org.bouncycastle", "bcpkix-jdk15on"),
-  "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.3-084d25b"
+  "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.6-1404496"
     exclude("com.typesafe.akka", "akka-protobuf-v3_2.13")
     exclude("com.google.protobuf", "protobuf-java"),
   "com.typesafe.akka" %% "akka-http" % akkaHttpV,

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -425,11 +425,19 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
         )
 
       case SnapshotReadyNotification(recipientUserId, snapshotExportLink, snapshotName, snapshotSummary) =>
-        thurloe.service.Notification(Option(recipientUserId), None, None, templateId, Map(
-          "snapshotExportLink" -> snapshotExportLink,
-          "snapshotName" -> snapshotName,
-          "snapshotSummary" -> snapshotSummary
-        ), Map.empty, Map.empty);
+        thurloe.service.Notification(
+          Option(recipientUserId),
+          None,
+          None,
+          templateId,
+          Map(
+            "snapshotExportLink" -> snapshotExportLink,
+            "snapshotName" -> snapshotName,
+            "snapshotSummary" -> snapshotSummary
+          ),
+          Map.empty,
+          Map.empty
+        );
     }
   }
 

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -423,6 +423,13 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
           Map("originEmail" -> requesterId),
           Map("userNameFL" -> requesterId)
         )
+
+      case SnapshotReadyNotification(recipientUserId, snapshotExportLink, snapshotName, snapshotSummary) =>
+        thurloe.service.Notification(Option(recipientUserId), None, None, templateId, Map(
+          "snapshotExportLink" -> snapshotExportLink,
+          "snapshotName" -> snapshotName,
+          "snapshotSummary" -> snapshotSummary
+        ), Map.empty, Map.empty);
     }
   }
 


### PR DESCRIPTION
Jira:  https://broadworkbench.atlassian.net/browse/DC-1186

What:

Add a new notification message for the TDR snapshot ready event.

Why:

In Terra, Thurloe is used to send messages.

How:

The dependency on workbenchLibs was tested locally by using `sbt publishLocal` and using a pinned snapshot version; once the workbench-libs and terra-helmfile PRs are merged, I can merge this change up and test the notification support in dev.

See also

https://github.com/broadinstitute/terra-helmfile/pull/5783
https://github.com/broadinstitute/workbench-libs/pull/1697

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
