### PR TITLE
[DC-962]Send email to Research Users after they request snapshot access

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Then use these commands to ensure git-hooks are run and start a server:
 
 ```
 $ cp -r hooks/ .git/hooks/ #this step can be skipped if you use the rsync script to spin up locally
-$ chmod 755 .git/hooks/apply-get-secrets.sh #this step as well
+$ chmod 755 .git/hooks/apply-git-secrets.sh #this step as well
 $ sbt run
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
     exclude("org.bouncycastle", "bcprov-ext-jdk15on")
     exclude("org.bouncycastle", "bcutil-jdk15on")
     exclude("org.bouncycastle", "bcpkix-jdk15on"),
-  "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.7-9254729"
+  "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.8-78b1597"
     exclude("com.typesafe.akka", "akka-protobuf-v3_2.13")
     exclude("com.google.protobuf", "protobuf-java"),
   "com.typesafe.akka" %% "akka-http" % akkaHttpV,

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -437,6 +437,22 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
           ),
           Map.empty,
           Map.empty
+        )
+
+      case SnapshotRequestSubmittedNotification(recipientUserId, requestName, requestId, dateSubmitted, requestSummary) =>
+        thurloe.service.Notification(
+          Option(recipientUserId),
+          None,
+          None,
+          templateId,
+          Map(
+            "requestName" -> requestName,
+            "requestId" -> requestId,
+            "dateSubmitted" -> dateSubmitted,
+            "requestSummary" -> requestSummary
+          ),
+          Map.empty,
+          Map.empty
         );
     }
   }

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -439,7 +439,11 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
           Map.empty
         )
 
-      case SnapshotRequestSubmittedNotification(recipientUserId, requestName, requestId, dateSubmitted, requestSummary) =>
+      case SnapshotRequestSubmittedNotification(recipientUserId,
+                                                requestName,
+                                                requestId,
+                                                dateSubmitted,
+                                                requestSummary) =>
         thurloe.service.Notification(
           Option(recipientUserId),
           None,


### PR DESCRIPTION
Note: pausing on this work until duos integration with data exploration is figured out

Jira: [DC-962](https://broadworkbench.atlassian.net/browse/DC-962)

What:

1. Adds a notification for when a snapshot request submitted on terra through the cohort builder.
2. Updates readme.

Why:

So researcher users will receive an email with information about their request upon submission. 

How:

Testing: The dependency on workbenchLibs was tested locally by using sbt publishLocal in workbench-notifications in workbenchLibs and then using the locally published snapshot version in thurloe.

Next: Once the workbench-libs and terra-helmfile PRs are merged, I can update the version of workbench-libs used here in thurloe, and then merge this change up and test the notification support in dev.

See also

https://github.com/broadinstitute/terra-helmfile/pull/5849
https://github.com/broadinstitute/workbench-libs/pull/1701

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them


[DC-962]: https://broadworkbench.atlassian.net/browse/DC-962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ