### PR TITLE
[CORE-27] Add CSP Header

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ resolvers ++= Seq(
   "Broad Artifactory Snapshots" at "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/")
 
 libraryDependencies ++= Seq(
-  "org.webjars" % "swagger-ui" % "4.1.3",
+  "org.webjars" % "swagger-ui" % "5.13.0",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.typesafe.akka" %% "akka-http-spray-json" % "10.2.9",
   "com.google.protobuf" % "protobuf-java" % "4.29.0-RC1",

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ resolvers ++= Seq(
   "Broad Artifactory Snapshots" at "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/")
 
 libraryDependencies ++= Seq(
-  "org.webjars" % "swagger-ui" % "5.13.0",
+  "org.webjars" % "swagger-ui" % "5.17.14",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.typesafe.akka" %% "akka-http-spray-json" % "10.2.9",
   "com.google.protobuf" % "protobuf-java" % "4.29.0-RC1",

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -9,6 +9,10 @@ akka.http {
   }
 }
 
+auth {
+  googleClientId = ""
+}
+
 swagger {
   docsPath = "swagger/thurloe.yaml"
   uiVersion = "2.1.1"

--- a/src/main/scala/thurloe/Main.scala
+++ b/src/main/scala/thurloe/Main.scala
@@ -10,6 +10,7 @@ import org.broadinstitute.dsde.workbench.util.toScalaDuration
 import thurloe.dataaccess.{HttpSamDAO, HttpSendGridDAO}
 import thurloe.dataaccess.auth.CloudServiceAuthTokenProvider
 import thurloe.notification.NotificationMonitorSupervisor
+import thurloe.security.CSPDirective.addCSP
 import thurloe.service.ThurloeServiceActor
 
 import java.io.File
@@ -41,7 +42,7 @@ object Main extends App {
   val routes = new ThurloeServiceActor(samDao)
 
   for {
-    binding <- Http().newServerAt("0.0.0.0", 8000).bind(routes.route).recover {
+    binding <- Http().newServerAt("0.0.0.0", 8000).bind(addCSP(routes.route)).recover {
       case t: Throwable =>
         system.log.error("FATAL - failure starting http server", t)
         throw t

--- a/src/main/scala/thurloe/Main.scala
+++ b/src/main/scala/thurloe/Main.scala
@@ -10,7 +10,6 @@ import org.broadinstitute.dsde.workbench.util.toScalaDuration
 import thurloe.dataaccess.{HttpSamDAO, HttpSendGridDAO}
 import thurloe.dataaccess.auth.CloudServiceAuthTokenProvider
 import thurloe.notification.NotificationMonitorSupervisor
-import thurloe.security.CSPDirective.addCSP
 import thurloe.service.ThurloeServiceActor
 
 import java.io.File
@@ -42,7 +41,7 @@ object Main extends App {
   val routes = new ThurloeServiceActor(samDao)
 
   for {
-    binding <- Http().newServerAt("0.0.0.0", 8000).bind(addCSP(routes.route)).recover {
+    binding <- Http().newServerAt("0.0.0.0", 8000).bind(routes.route).recover {
       case t: Throwable =>
         system.log.error("FATAL - failure starting http server", t)
         throw t

--- a/src/main/scala/thurloe/security/CSPDirective.scala
+++ b/src/main/scala/thurloe/security/CSPDirective.scala
@@ -1,0 +1,13 @@
+package thurloe.security
+
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+
+object CSPDirective {
+  private val cspHeader = RawHeader("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';")
+
+  def addCSP(route: Route): Route = respondWithHeader(cspHeader) {
+    route
+  }
+}

--- a/src/main/scala/thurloe/security/CSPDirective.scala
+++ b/src/main/scala/thurloe/security/CSPDirective.scala
@@ -5,7 +5,10 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 
 object CSPDirective {
-  private val cspHeader = RawHeader("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';")
+  private val cspHeader = RawHeader(
+    "Content-Security-Policy",
+    "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self'; form-action 'none';"
+  )
 
   def addCSP(route: Route): Route = respondWithHeader(cspHeader) {
     route

--- a/src/main/scala/thurloe/service/ThurloeServiceActor.scala
+++ b/src/main/scala/thurloe/service/ThurloeServiceActor.scala
@@ -15,7 +15,7 @@ class ThurloeServiceActor(httpSamDao: SamDAO) extends FireCloudProtectedServices
   val samDao = httpSamDao
   override val dataAccess = ThurloeDatabaseConnector
   override val sendGridDAO = new HttpSendGridDAO(samDao)
-  protected val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/5.13.0"
+  protected val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/5.17.14"
 
   def route: Route =
     swaggerUiService ~ statusRoute ~ fireCloudProtectedRoutes

--- a/src/main/scala/thurloe/service/ThurloeServiceActor.scala
+++ b/src/main/scala/thurloe/service/ThurloeServiceActor.scala
@@ -15,7 +15,7 @@ class ThurloeServiceActor(httpSamDao: SamDAO) extends FireCloudProtectedServices
   val samDao = httpSamDao
   override val dataAccess = ThurloeDatabaseConnector
   override val sendGridDAO = new HttpSendGridDAO(samDao)
-  protected val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/4.1.3"
+  protected val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/5.13.0"
 
   def route: Route =
     swaggerUiService ~ statusRoute ~ fireCloudProtectedRoutes

--- a/src/test/scala/thurloe/service/ThurloeServiceActorSpec.scala
+++ b/src/test/scala/thurloe/service/ThurloeServiceActorSpec.scala
@@ -1,0 +1,31 @@
+package thurloe.service
+
+import org.mockito.MockitoSugar.mock
+import thurloe.dataaccess.{HttpSamDAO}
+import akka.http.scaladsl.model.HttpHeader
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.funspec.AnyFunSpec
+import thurloe.service.ThurloeServiceActor
+
+class ThurloeServiceActorSpec extends AnyFunSpec with Matchers with ScalatestRouteTest {
+
+  val service = new ThurloeServiceActor(mock[HttpSamDAO])
+
+  describe("ThurloeServiceActor"){
+
+    it("include Content-Security-Policy header in main route"){
+      Get("/") ~> service.route ~> check {
+        val cspHeader: Option[HttpHeader] = header("Content-Security-Policy")
+        cspHeader shouldBe defined
+        cspHeader.get.value should include("default-src 'self'")
+        cspHeader.get.value should include("script-src 'self' 'unsafe-inline'")
+
+        assertResult(StatusCodes.OK) {
+          status
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/thurloe/service/ThurloeServiceActorSpec.scala
+++ b/src/test/scala/thurloe/service/ThurloeServiceActorSpec.scala
@@ -1,23 +1,20 @@
 package thurloe.service
 
-import org.mockito.MockitoSugar.mock
-import thurloe.dataaccess.{HttpSamDAO}
-import akka.http.scaladsl.model.HttpHeader
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.matchers.should.Matchers
+import org.mockito.MockitoSugar.mock
 import org.scalatest.funspec.AnyFunSpec
-import thurloe.service.ThurloeServiceActor
+import org.scalatest.matchers.should.Matchers
+import thurloe.dataaccess.HttpSamDAO
 
 class ThurloeServiceActorSpec extends AnyFunSpec with Matchers with ScalatestRouteTest {
 
   val service = new ThurloeServiceActor(mock[HttpSamDAO])
 
-  describe("ThurloeServiceActor"){
-
-    it("include Content-Security-Policy header in main route"){
+  describe("ThurloeServiceActor") {
+    it("include Content-Security-Policy header in main route") {
       Get("/") ~> service.route ~> check {
-        val cspHeader: Option[HttpHeader] = header("Content-Security-Policy")
+        val cspHeader = header("Content-Security-Policy")
         cspHeader shouldBe defined
         cspHeader.get.value should include("default-src 'self'")
         cspHeader.get.value should include("script-src 'self' 'unsafe-inline'")


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-27

**Description:**

This PR adds a Content Security Policy (CSP) header to the Thurloe Swagger page and endpoints to enhance security by reducing the risk of cross-site scripting (XSS) and data injection attacks.

**Testing:**

- Added tests for csp header and ran them successfully 
- Compiled project and observed no issues

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
