### PR TITLE
CORE-127: enforce scalafmt in github actions

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# .git-blame-ignore-revs
+
+# scalafmt mass change
+3487e7a60194a66886572c899a6a93d7355dc376

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,28 @@
+name: Check formatting for modified files with scalafmt
+
+on:
+  pull_request:
+    paths-ignore: ['**.md']
+
+jobs:
+  format:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: sbt
+
+      - name: Check formatting for modified files
+        run: |
+          sbt scalafmtCheckAll


### PR DESCRIPTION
Followup to #337

That other PR performed a mass reformat of code to meet `scalafmt` standards.

This PR adds:
* a format check in github actions for PRs
* introduction of `.git-blame-ignore-revs`, so the mass reformat doesn't show up in git blames