### PR TITLE
CORE-69: scala, sbt, plugins updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "0.2"
 
 organization := "org.broadinstitute"
 
-scalaVersion := "2.13.10"
+scalaVersion := "2.13.15"
 
 val akkaV = "2.6.18"
 val akkaHttpV = "10.2.7"

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val akkaV = "2.6.18"
 val akkaHttpV = "10.2.7"
 val slickV = "3.3.3"
 val workbenchGoogleV = "0.28-3ad3700"
-val scalaTestV = "3.2.11"
+val scalaTestV = "3.2.19"
 
 resolvers ++= Seq(
   "Broad Artifactory Releases" at "https://broadinstitute.jfrog.io/broadinstitute/libs-release/",
@@ -58,7 +58,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-testkit" % akkaV % Test,
   "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % Test,
   "org.scalatest" %% "scalatest" % scalaTestV % Test,
-  "org.mockito" %% "mockito-scala-scalatest" % "1.17.12" % Test,
+  "org.mockito" %% "mockito-scala-scalatest" % "1.17.37" % Test,
   "org.yaml" % "snakeyaml" % "1.33" % Test
 )
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -89,7 +89,7 @@ fi
 function make_jar()
 {
 	echo "building thurloe jar..."
-	docker run --rm -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:openjdk-17.0.2_1.7.2_2.13.10 /working/docker/install.sh /working
+	docker run --rm -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.13_11_1.10.5_2.13.15 /working/docker/install.sh /working
 }
 
 function docker_cmd()

--- a/docker/build_jar.sh
+++ b/docker/build_jar.sh
@@ -10,7 +10,7 @@ echo "building thurloe jar..."
 
 docker run --rm -v $PWD:/working \
 -v jar-cache:/root/.ivy \
--v jar-cache:/root/.ivy2 sbtscala/scala-sbt:openjdk-17.0.2_1.7.2_2.13.10 /working/docker/install.sh /working
+-v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.13_11_1.10.5_2.13.15 /working/docker/install.sh /working
 
 
 EXIT_CODE=$?

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.10.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,13 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.1")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
 addSbtPlugin(
-  "com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16"
+  "com.github.cb372" % "sbt-explicit-dependencies" % "0.3.1"
 ) // Use `unusedCompileDependencies` to see unused dependencies
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.13.0")
 
 addDependencyTreePlugin

--- a/src/main/scala/thurloe/service/ApiDataModels.scala
+++ b/src/main/scala/thurloe/service/ApiDataModels.scala
@@ -5,13 +5,13 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport.{
   WorkbenchEmailFormat,
   WorkbenchUserIdFormat
 }
-import spray.json.DefaultJsonProtocol
+import spray.json.{DefaultJsonProtocol, RootJsonFormat}
 
 object ApiDataModelsJsonProtocol extends DefaultJsonProtocol {
-  implicit val keyValuePairFormat = jsonFormat2(KeyValuePair)
-  implicit val userKeyValuePairFormat = jsonFormat2(UserKeyValuePair)
-  implicit val userKeyValuePairsFormat = jsonFormat2(UserKeyValuePairs)
-  implicit val notificationFormat = jsonFormat7(Notification)
+  implicit val keyValuePairFormat: RootJsonFormat[KeyValuePair] = jsonFormat2(KeyValuePair)
+  implicit val userKeyValuePairFormat: RootJsonFormat[UserKeyValuePair] = jsonFormat2(UserKeyValuePair)
+  implicit val userKeyValuePairsFormat: RootJsonFormat[UserKeyValuePairs] = jsonFormat2(UserKeyValuePairs)
+  implicit val notificationFormat: RootJsonFormat[Notification] = jsonFormat7(Notification)
 }
 
 object ThurloeQuery {


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-69

Updates Scala, sbt, sbt plugins, and the scala-sbt docker image. Makes some very minor syntax tweaks to address syntax that was previously allowed but in the new version of Scala is now illegal. Updates scalatest and mockito-scala-scalatest.

This consolidates Scala Steward PRs #343, #281, #322, #323, #327, #288, #289.




---

- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
