### PR TITLE
CORE-69: update workbench-libs dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,13 @@ scalaVersion := "2.13.15"
 val akkaV = "2.6.18"
 val akkaHttpV = "10.2.7"
 val slickV = "3.3.3"
-val workbenchGoogleV = "0.28-3ad3700"
+
 val scalaTestV = "3.2.19"
+
+val workbenchLibsHash = "9254729"
+val workbenchGoogleV = s"0.32-$workbenchLibsHash"
+val workbenchNotificationsV = s"0.7-$workbenchLibsHash"
+
 
 resolvers ++= Seq(
   "Broad Artifactory Releases" at "https://broadinstitute.jfrog.io/broadinstitute/libs-release/",
@@ -32,7 +37,7 @@ libraryDependencies ++= Seq(
     exclude("org.bouncycastle", "bcprov-ext-jdk15on")
     exclude("org.bouncycastle", "bcutil-jdk15on")
     exclude("org.bouncycastle", "bcpkix-jdk15on"),
-  "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.7-9254729"
+  "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % workbenchNotificationsV
     exclude("com.typesafe.akka", "akka-protobuf-v3_2.13")
     exclude("com.google.protobuf", "protobuf-java"),
   "com.typesafe.akka" %% "akka-http" % akkaHttpV,


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-69

Updates workbench-google and workbench-notifications to somewhat recent versions. Supersedes #312, #331, and #332.

Note that we cannot update to the very latest versions of these workbench-libs dependencies. The update from workbench-notifications 0.7 to 0.8 introduces a new `SnapshotRequestSubmittedNotification` notification type. The [match statement](https://github.com/broadinstitute/thurloe/blob/62709c8aa7517b9aa722a370385a18d1d34f9d59/src/main/scala/thurloe/notification/NotificationMonitor.scala#L263) that processes notifications will not be exhaustive on 0.8, and compilation will fail. See #310 for the PR that will address that.

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
