### PR TITLE
CORE-69: swagger-ui webjar to 5.18.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ resolvers ++= Seq(
   "Broad Artifactory Snapshots" at "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/")
 
 libraryDependencies ++= Seq(
-  "org.webjars" % "swagger-ui" % "5.17.14",
+  "org.webjars" % "swagger-ui" % "5.18.2",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "com.typesafe.akka" %% "akka-http-spray-json" % "10.2.9",
   "com.google.protobuf" % "protobuf-java" % "4.29.0-RC1",

--- a/src/main/scala/thurloe/service/ThurloeServiceActor.scala
+++ b/src/main/scala/thurloe/service/ThurloeServiceActor.scala
@@ -15,7 +15,7 @@ class ThurloeServiceActor(httpSamDao: SamDAO) extends FireCloudProtectedServices
   val samDao = httpSamDao
   override val dataAccess = ThurloeDatabaseConnector
   override val sendGridDAO = new HttpSendGridDAO(samDao)
-  protected val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/5.17.14"
+  private val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/5.18.2"
 
   def route: Route = addCSP {
     swaggerUiService ~ statusRoute ~ fireCloudProtectedRoutes


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-69

This is a fixed version of #349. When updating swagger-ui, we also need to update our path to the swagger-ui webjar. Supersedes #349.

---

- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
