### PR TITLE
CORE-69: scala steward config

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -27,7 +27,7 @@
 # Default: @asap
 #
 #pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
-pullRequests.frequency = "0 12 1,16 * *" # every 1st and 16th of the month at noon
+pullRequests.frequency = "0 12 1,16 * ?" # every 1st and 16th of the month at noon
 
 # Only these dependencies which match the given patterns are updated.
 #
@@ -63,18 +63,23 @@ updates.includeScala = true
 # Default: [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", "pom.xml"]
 updates.fileExtensions = [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", ".md", ".markdown", ".txt"]
 
+# If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).
+# Useful if running frequently and/or CI build are costly
+# Default: None
+updates.limit = 5
+
 # If "on-conflicts", Scala Steward will update the PR it created to resolve conflicts as
 # long as you don't change it yourself.
 # If "always", Scala Steward will always update the PR it created as long as
 # you don't change it yourself.
 # If "never", Scala Steward will never update the PR
 # Default: "on-conflicts"
-updatePullRequests = "always"
+updatePullRequests = "on-conflicts"
 
 # If set, Scala Steward will use this message template for the commit messages and PR titles.
 # Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}
 # Default: "${default}" which is equivalent to "Update ${artifactName} to ${nextVersion}"
-commits.message = "(Broadbot) Update ${artifactName} from ${currentVersion} to ${nextVersion}"
+commits.message = "CORE-69: Update ${artifactName} from ${currentVersion} to ${nextVersion}"
 
 # If true and when upgrading version in .scalafmt.conf, Scala Steward will perform scalafmt
 # and add a separate commit when format changed. So you don't need reformat manually and can merge PR.

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -28,6 +28,44 @@
 #
 pullRequests.frequency = "0 3 ? * 3" # every thursday at 3am
 
+# pullRequests.customLabels allows to add custom labels to PRs.
+# This is useful if you want to use the labels for automation (project board for example).
+# Defaults to no labels (no labels are added).
+pullRequests.customLabels = [ "Scala_Steward" ]
+
+# pullRequests.grouping allows you to specify how Scala Steward should group
+# your updates in order to reduce the number of pull-requests.
+#
+# Updates will be placed in the first group with which they match, starting
+# from the first in the array. Those that do not match any group will follow
+# the default procedure (one PR per update).
+#
+# Each element in the array will have the following schema:
+#
+#   - name (mandatory): the name of the group, will be used for things like naming the branch
+#   - title (optional): if provided it will be used as the title for the PR
+#   - filter (mandatory): a non-empty list containing the filters to use to know
+#                         if an update falls into this group.
+#
+# `filter` properties would have this format:
+#
+#    {
+#       version = "major" | "minor" | "patch" | "pre-release" | "build-metadata",
+#       group = "{group}",
+#       artifact = "{artifact}"
+#    }
+#
+# For more information on the values for the `version` filter visit https://semver.org/
+#
+# Every field in a `filter` is optional but at least one must be provided.
+#
+# For grouping every update together a filter like {group = "*"} can be # provided.
+#
+# To create a new PR for each unique combination of artifact-versions, include ${hash} in the name.
+#
+# Default: []
+pullRequests.grouping = [ { name = "minor_patch", title = "CORE-69: Minor and patch updates - ${artifactVersions}", filter = [ { version = "minor" }, { version = "patch" } ] } ]
+
 # Only these dependencies which match the given patterns are updated.
 #
 # Each pattern must have `groupId`, and may have `artifactId` and `version`.

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -26,8 +26,7 @@
 #
 # Default: @asap
 #
-#pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
-pullRequests.frequency = "0 12 1,16 * ?" # every 1st and 16th of the month at noon
+pullRequests.frequency = "0 3 ? * 3" # every thursday at 3am
 
 # Only these dependencies which match the given patterns are updated.
 #


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-69

Updates the Scala Steward config file. Note that the current config has a mistake and is not currently in use. For instance, see https://github.com/broadinstitute/thurloe/pull/349 and notice the "Note that the Scala Steward config file `.scala-steward.conf` wasn't parsed correctly" message in the PR description.

Changes to config:
* limit to 5 PRs per Scala Steward run
* move to "on-conflicts" mode for updating PRs
* prefix PR titles with "CORE-69:"
* fix the cron expression. This is the part that was causing parsing to fail. Since parsing was failing, Scala Steward was defaulting to "@asap" and I am changing that to weekly.
* add grouping of minor/patch updates
* add labels


---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
