### PR TITLE
CORE-69: remove explicit dependency on snakeyaml

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,8 +62,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-testkit" % akkaV % Test,
   "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % Test,
   "org.scalatest" %% "scalatest" % scalaTestV % Test,
-  "org.mockito" %% "mockito-scala-scalatest" % "1.17.37" % Test,
-  "org.yaml" % "snakeyaml" % "1.33" % Test
+  "org.mockito" %% "mockito-scala-scalatest" % "1.17.37" % Test
 )
 
 scalacOptions ++= Seq(


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-69

Removes the explicit dependency on snakeyaml. This supersedes #311.

When pulled in transitively, without the explicit dependency declaration, snakeyaml is at version 2.3:

![Screenshot 2024-11-13 at 2 51 33 PM](https://github.com/user-attachments/assets/ebdab455-2b61-4ee7-8406-9759871b38a2)

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
