### PR TITLE
TSPS-140 Add Teaspoons notification types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,9 @@ val slickV = "3.5.2"
 
 val scalaTestV = "3.2.19"
 
-val workbenchLibsHash = "9254729"
-val workbenchGoogleV = s"0.32-$workbenchLibsHash"
-val workbenchNotificationsV = s"0.7-$workbenchLibsHash"
+val workbenchLibsHash = "80b39af"
+val workbenchGoogleV = s"0.33-$workbenchLibsHash"
+val workbenchNotificationsV = s"0.8-$workbenchLibsHash"
 
 resolvers ++= Seq(
   "Broad Artifactory Releases" at "https://broadinstitute.jfrog.io/broadinstitute/libs-release/",

--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,9 @@ val slickV = "3.5.2"
 
 val scalaTestV = "3.2.19"
 
-val workbenchLibsHash = "80b39af"
+val workbenchLibsHash = "5d9c477"
 val workbenchGoogleV = s"0.33-$workbenchLibsHash"
-val workbenchNotificationsV = s"0.8-$workbenchLibsHash"
+val workbenchNotificationsV = s"0.9-$workbenchLibsHash"
 
 resolvers ++= Seq(
   "Broad Artifactory Releases" at "https://broadinstitute.jfrog.io/broadinstitute/libs-release/",

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -449,6 +449,60 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
           ),
           Map.empty,
           Map.empty
+        )
+
+      case TeaspoonsJobSucceededNotification(recipientUserId,
+                                             pipelineDisplayName,
+                                             jobId,
+                                             timeSubmitted,
+                                             timeCompleted,
+                                             quotaConsumedByJob,
+                                             quotaRemaining,
+                                             userDescription) =>
+        thurloe.service.Notification(
+          Option(recipientUserId),
+          None,
+          None,
+          templateId,
+          Map(
+            "pipelineDisplayName" -> pipelineDisplayName,
+            "jobId" -> jobId,
+            "timeSubmitted" -> timeSubmitted,
+            "timeCompleted" -> timeCompleted,
+            "quotaConsumedByJob" -> quotaConsumedByJob,
+            "quotaRemaining" -> quotaRemaining,
+            "userDescription" -> userDescription
+          ),
+          Map.empty,
+          Map.empty
+        )
+
+      case TeaspoonsJobFailedNotification(recipientUserId,
+                                          pipelineDisplayName,
+                                          jobId,
+                                          errorMessage,
+                                          timeSubmitted,
+                                          timeCompleted,
+                                          quotaConsumedByJob,
+                                          quotaRemaining,
+                                          userDescription) =>
+        thurloe.service.Notification(
+          Option(recipientUserId),
+          None,
+          None,
+          templateId,
+          Map(
+            "pipelineDisplayName" -> pipelineDisplayName,
+            "jobId" -> jobId,
+            "errorMessage" -> errorMessage,
+            "timeSubmitted" -> timeSubmitted,
+            "timeCompleted" -> timeCompleted,
+            "quotaConsumedByJob" -> quotaConsumedByJob,
+            "quotaRemaining" -> quotaRemaining,
+            "userDescription" -> userDescription
+          ),
+          Map.empty,
+          Map.empty
         );
     }
   }

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -458,7 +458,8 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
                                              timeCompleted,
                                              quotaConsumedByJob,
                                              quotaRemaining,
-                                             userDescription) =>
+                                             userDescription
+          ) =>
         thurloe.service.Notification(
           Option(recipientUserId),
           None,
@@ -485,7 +486,8 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
                                           timeCompleted,
                                           quotaConsumedByJob,
                                           quotaRemaining,
-                                          userDescription) =>
+                                          userDescription
+          ) =>
         thurloe.service.Notification(
           Option(recipientUserId),
           None,


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/TSPS-140

What:

Add two new notification messages for Teaspoons succeeded and failed jobs.

Why:

In Terra, Thurloe is used to send messages.

How:

Once this PR is merged, I can test the notification support in dev.

See also:
https://github.com/broadinstitute/terra-helmfile/pull/5984
https://github.com/broadinstitute/workbench-libs/pull/1714

following pattern from similar work for TDR: https://github.com/broadinstitute/thurloe/pull/301

Note that the following workbench-libs PR also had to be merged to roll back some changes that were causing tests to fail; the workbench-libs version used here comes from this PR: https://github.com/broadinstitute/workbench-libs/pull/1715

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
