### PR TITLE
CORE-69: update sbt and docker images to 1.10.7

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -89,7 +89,7 @@ fi
 function make_jar()
 {
 	echo "building thurloe jar..."
-	docker run --rm -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.13_11_1.10.5_2.13.15 /working/docker/install.sh /working
+	docker run --rm -v $PWD:/working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.13_11_1.10.7_2.13.15 /working/docker/install.sh /working
 }
 
 function docker_cmd()

--- a/docker/build_jar.sh
+++ b/docker/build_jar.sh
@@ -10,7 +10,7 @@ echo "building thurloe jar..."
 
 docker run --rm -v $PWD:/working \
 -v jar-cache:/root/.ivy \
--v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.13_11_1.10.5_2.13.15 /working/docker/install.sh /working
+-v jar-cache:/root/.ivy2 sbtscala/scala-sbt:eclipse-temurin-17.0.13_11_1.10.7_2.13.15 /working/docker/install.sh /working
 
 
 EXIT_CODE=$?

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.5
+sbt.version=1.10.7


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-69

Update `sbt` and the `scala-sbt` docker image tags to 1.10.7

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
