### PR TITLE
CORE-235: sendgrid-java 4.10.3 and corresponding syntax changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ libraryDependencies ++= Seq(
   "mysql" % "mysql-connector-java" % "8.0.28",
   "org.liquibase" % "liquibase-core" % "4.30.0",
   "org.hsqldb" % "hsqldb" % "2.7.4",
-  "com.sendgrid" % "sendgrid-java" % "2.2.2",
+  "com.sendgrid" % "sendgrid-java" % "4.10.3",
   "ch.qos.logback" % "logback-classic" % "1.5.16",
   "org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-4cde1ff",
   "com.azure" % "azure-identity" % "1.14.2",

--- a/build.sbt
+++ b/build.sbt
@@ -117,6 +117,7 @@ val customMergeStrategy: String => MergeStrategy = {
     }
   case PathList("javax", "annotation", _@_*) => MergeStrategy.first
   case "NOTICE" => MergeStrategy.discard
+  case "LICENSE" => MergeStrategy.first
   case "module-info.class" => MergeStrategy.discard
   case "reference.conf" => MergeStrategy.concat
   case _ => MergeStrategy.deduplicate

--- a/src/main/scala/thurloe/dataaccess/HttpSendGridDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/HttpSendGridDAO.scala
@@ -1,8 +1,8 @@
 package thurloe.dataaccess
 
 import akka.http.scaladsl.model.StatusCodes
-import com.sendgrid.SendGrid.Response
-import com.sendgrid._
+import com.sendgrid.{Method, Request, Response, SendGrid}
+import com.sendgrid.helpers.mail.Mail
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUserId}
 import thurloe.database.{KeyNotFoundException, ThurloeDatabaseConnector}
@@ -16,18 +16,23 @@ import scala.concurrent.Future
 class HttpSendGridDAO(samDao: SamDAO) extends SendGridDAO with LazyLogging {
   val dataAccess = ThurloeDatabaseConnector
 
-  override def sendEmail(email: SendGrid.Email): Future[Response] = {
+  override def sendEmail(email: Mail): Future[Response] = {
     val sendGrid = new SendGrid(apiKey)
 
     Future {
-      val response = sendGrid.send(email)
-      if (response.getStatus) response
+      val sgRequest = new Request()
+      sgRequest.setMethod(Method.POST)
+      sgRequest.setEndpoint("mail/send")
+      sgRequest.setBody(email.build)
+
+      val response = sendGrid.api(sgRequest)
+      if (isSuccessful(response)) response
       else
         throw new NotificationException(
           StatusCodes.InternalServerError,
-          "Unable to send notification, unexpected error occurred: " + response.getMessage,
-          email.getTos.toSeq,
-          email.getFilters.getJSONObject("templates").getJSONObject("settings").getString("template_id")
+          "Unable to send notification, unexpected error occurred: " + response.getBody,
+          getTos(email),
+          email.getTemplateId
         )
     }
   }

--- a/src/main/scala/thurloe/dataaccess/HttpSendGridDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/HttpSendGridDAO.scala
@@ -16,23 +16,23 @@ import scala.concurrent.Future
 class HttpSendGridDAO(samDao: SamDAO) extends SendGridDAO with LazyLogging {
   val dataAccess = ThurloeDatabaseConnector
 
-  override def sendEmail(email: Mail): Future[Response] = {
+  override def sendMail(mail: Mail): Future[Response] = {
     val sendGrid = new SendGrid(apiKey)
 
     Future {
-      val sgRequest = new Request()
-      sgRequest.setMethod(Method.POST)
-      sgRequest.setEndpoint("mail/send")
-      sgRequest.setBody(email.build)
+      val request = new Request()
+      request.setMethod(Method.POST)
+      request.setEndpoint("mail/send")
+      request.setBody(mail.build)
 
-      val response = sendGrid.api(sgRequest)
+      val response = sendGrid.api(request)
       if (isSuccessful(response)) response
       else
-        throw new NotificationException(
+        throw NotificationException(
           StatusCodes.InternalServerError,
           "Unable to send notification, unexpected error occurred: " + response.getBody,
-          getTos(email),
-          email.getTemplateId
+          getTos(mail),
+          mail.getTemplateId
         )
     }
   }

--- a/src/main/scala/thurloe/dataaccess/SendGridDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/SendGridDAO.scala
@@ -23,7 +23,7 @@ trait SendGridDAO {
   val defaultFromAddress =
     new Email(sendGridConfig.getString("defaultFromAddress"), sendGridConfig.getString("defaultFromName"))
 
-  def sendEmail(email: Mail): Future[Response]
+  def sendMail(mail: Mail): Future[Response]
   def lookupPreferredEmail(userId: WorkbenchUserId): Future[WorkbenchEmail]
   def lookupUserName(userId: WorkbenchUserId): Future[String]
   def lookupUserFirstName(userId: WorkbenchUserId): Future[String]
@@ -69,8 +69,8 @@ trait SendGridDAO {
         emailSubstitutions <- emailSubstitutionsFuture
         nameSubstitution <- nameSubstitutionsFuture
         recipientFirstNameSubstitution <- recipientFirstNameSubstitutionFuture
-        response <- sendEmail(
-          createEmail(
+        response <- sendMail(
+          createMail(
             toAddress,
             replyTos,
             notification.notificationId,
@@ -84,30 +84,30 @@ trait SendGridDAO {
     Note: email.setSubject and email.setText must be set even if their values
     aren't used. Supposedly this will be fixed in a future version of SendGrid
    */
-  def createEmail(toAddress: WorkbenchEmail,
-                  replyTos: Option[Set[WorkbenchEmail]],
-                  notificationId: String,
-                  substitutions: Map[String, String] = Map.empty
+  def createMail(toAddress: WorkbenchEmail,
+                 replyTos: Option[Set[WorkbenchEmail]],
+                 notificationId: String,
+                 substitutions: Map[String, String] = Map.empty
   ): Mail = {
-    val email = new Mail()
+    val mail = new Mail()
 
     // set recipient
     val personalization = new Personalization()
     personalization.addTo(new Email(toAddress.value))
     addSubstitutions(personalization, substitutions)
 
-    email.setFrom(defaultFromAddress)
-    email.setTemplateId(notificationId)
-    email.setSubject(" ")
+    mail.setFrom(defaultFromAddress)
+    mail.setTemplateId(notificationId)
+    mail.setSubject(" ")
 
-    email.addPersonalization(personalization)
+    mail.addPersonalization(personalization)
 
     replyTos.foreach { userEmails =>
       val addrs = userEmails.map(_.value)
-      email.addHeader("Reply-To", addrs.mkString(", "))
+      mail.addHeader("Reply-To", addrs.mkString(", "))
     }
 
-    email
+    mail
   }
 
   def isSuccessful(response: Response): Boolean =

--- a/src/main/scala/thurloe/dataaccess/SendGridDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/SendGridDAO.scala
@@ -104,7 +104,7 @@ trait SendGridDAO {
 
     replyTos.foreach { userEmails =>
       val addrs = userEmails.map(_.value)
-      mail.addHeader("Reply-To", addrs.mkString(", "))
+      mail.setReplyTo(new Email(addrs.mkString(", ")))
     }
 
     mail

--- a/src/main/scala/thurloe/dataaccess/SendGridDAO.scala
+++ b/src/main/scala/thurloe/dataaccess/SendGridDAO.scala
@@ -1,14 +1,18 @@
 package thurloe.dataaccess
 
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
-import com.sendgrid.SendGrid
-import com.sendgrid.SendGrid.Response
+import com.sendgrid.Response
+import com.sendgrid.helpers.mail.Mail
+import com.sendgrid.helpers.mail.objects.{Email, Personalization}
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUserId}
 import thurloe.service.Notification
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.CollectionConverters._
+
+import scala.util.Try
 
 trait SendGridDAO {
 
@@ -16,10 +20,10 @@ trait SendGridDAO {
   val sendGridConfig = configFile.getConfig("sendgrid")
   val apiKey = sendGridConfig.getString("apiKey")
   val substitutionChar = sendGridConfig.getString("substitutionChar")
-  val defaultFromAddress = sendGridConfig.getString("defaultFromAddress")
-  val defaultFromName = sendGridConfig.getString("defaultFromName")
+  val defaultFromAddress =
+    new Email(sendGridConfig.getString("defaultFromAddress"), sendGridConfig.getString("defaultFromName"))
 
-  def sendEmail(email: SendGrid.Email): Future[Response]
+  def sendEmail(email: Mail): Future[Response]
   def lookupPreferredEmail(userId: WorkbenchUserId): Future[WorkbenchEmail]
   def lookupUserName(userId: WorkbenchUserId): Future[String]
   def lookupUserFirstName(userId: WorkbenchUserId): Future[String]
@@ -84,22 +88,32 @@ trait SendGridDAO {
                   replyTos: Option[Set[WorkbenchEmail]],
                   notificationId: String,
                   substitutions: Map[String, String] = Map.empty
-  ): SendGrid.Email = {
-    val email = new SendGrid.Email()
+  ): Mail = {
+    val email = new Mail()
 
-    email.addTo(toAddress.value)
+    // set recipient
+    val personalization = new Personalization()
+    personalization.addTo(new Email(toAddress.value))
+    addSubstitutions(personalization, substitutions)
+
     email.setFrom(defaultFromAddress)
     email.setTemplateId(notificationId)
     email.setSubject(" ")
-    email.setFromName(defaultFromName)
-    replyTos.map { userEmails =>
+
+    email.addPersonalization(personalization)
+
+    replyTos.foreach { userEmails =>
       val addrs = userEmails.map(_.value)
       email.addHeader("Reply-To", addrs.mkString(", "))
     }
-    email.setHtml(" ")
-    addSubstitutions(email, substitutions)
+
     email
   }
+
+  def isSuccessful(response: Response): Boolean =
+    Try(StatusCode.int2StatusCode(response.getStatusCode).isSuccess()).getOrElse(false)
+
+  def getTos(mail: Mail): Seq[String] = mail.getPersonalization.asScala.flatMap(_.getTos.asScala.map(_.getEmail)).toSeq
 
   /*
     Adds a set of substitutions to an email template.
@@ -107,8 +121,8 @@ trait SendGridDAO {
     "You have been added to workspace %workspaceName%" will result in this substitution:
     "You have been added to workspace TCGA_BRCA"
    */
-  private def addSubstitutions(email: SendGrid.Email, substitution: Map[String, String]): Unit =
-    substitution.foreach(sub => email.addSubstitution(wrapSubstitution(sub._1), Array(sub._2)))
+  private def addSubstitutions(personalization: Personalization, substitution: Map[String, String]): Unit =
+    substitution.foreach(sub => personalization.addSubstitution(wrapSubstitution(sub._1), sub._2))
 
   private def wrapSubstitution(keyword: String): String = s"$substitutionChar$keyword$substitutionChar"
 

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -3,7 +3,7 @@ package thurloe.notification
 import akka.actor.SupervisorStrategy.{Escalate, Stop}
 import akka.actor._
 import akka.pattern._
-import com.sendgrid.SendGrid.Response
+import com.sendgrid.Response
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO
@@ -181,9 +181,9 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
         .acknowledgeMessagesById(pubSubSubscriptionName, Seq(message.ackId))
         .map(_ => StartMonitorPass) pipeTo self
       responseOption match {
-        case Some(response: Response) if !response.getStatus =>
+        case Some(response: Response) if !sendGridDAO.isSuccessful(response) =>
           logger.error(
-            s"could not send notification ${message.contents}, sendgrid code: ${response.getCode}, sendgrid message: ${response.getMessage}"
+            s"could not send notification ${message.contents}, sendgrid code: ${response.getStatusCode}, sendgrid message: ${response.getBody}"
           )
         case _ => // log nothing
       }

--- a/src/test/scala/thurloe/dataaccess/MockSendGridDAO.scala
+++ b/src/test/scala/thurloe/dataaccess/MockSendGridDAO.scala
@@ -24,9 +24,9 @@ class MockSendGridDAO extends SendGridDAO {
 
   val emails = Collections.synchronizedList(new util.ArrayList[Mail]())
 
-  override def sendEmail(email: Mail): Future[Response] = Future {
-    val usedId = email.getTemplateId
-    email match {
+  override def sendMail(mail: Mail): Future[Response] = Future {
+    val usedId = mail.getTemplateId
+    mail match {
       case e
           if validNotificationIds
             .contains(e.getTemplateId) =>

--- a/src/test/scala/thurloe/dataaccess/MockSendGridDAO.scala
+++ b/src/test/scala/thurloe/dataaccess/MockSendGridDAO.scala
@@ -1,8 +1,8 @@
 package thurloe.dataaccess
 
 import akka.http.scaladsl.model.StatusCodes
-import com.sendgrid.SendGrid.Response
-import com.sendgrid._
+import com.sendgrid.Response
+import com.sendgrid.helpers.mail.Mail
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUserId}
 import thurloe.database.KeyNotFoundException
 import thurloe.service.Notification
@@ -18,18 +18,18 @@ import scala.concurrent.Future
 class MockSendGridDAO extends SendGridDAO {
 
   val desiredFrom = "good_from_user"
-  val ok = new Response(200, "OK")
+  val ok = new Response(200, "OK", java.util.Map.of())
 
   val validNotificationIds = Seq("valid_notification_id1", "valid_notification_id2")
 
-  val emails = Collections.synchronizedList(new util.ArrayList[SendGrid.Email]())
+  val emails = Collections.synchronizedList(new util.ArrayList[Mail]())
 
-  override def sendEmail(email: SendGrid.Email): Future[Response] = Future {
-    val usedId = email.getFilters.getJSONObject("templates").getJSONObject("settings").getString("template_id")
+  override def sendEmail(email: Mail): Future[Response] = Future {
+    val usedId = email.getTemplateId
     email match {
       case e
           if validNotificationIds
-            .contains(e.getFilters.getJSONObject("templates").getJSONObject("settings").getString("template_id")) =>
+            .contains(e.getTemplateId) =>
         emails.add(e)
         ok
       case _ =>

--- a/src/test/scala/thurloe/notification/NotificationMonitorSpec.scala
+++ b/src/test/scala/thurloe/notification/NotificationMonitorSpec.scala
@@ -99,7 +99,7 @@ class NotificationMonitorSpec(_system: ActorSystem)
 
     awaitAssert(
       assertResult(testNotifications.map(n => n.requesterId.value).toSet) {
-        sendGridDAO.emails.asScala.map(email => email.getHeaders.get("Reply-To")).toSet
+        sendGridDAO.emails.asScala.map(email => email.getReplyto.getEmail).toSet
       },
       10 seconds
     )

--- a/src/test/scala/thurloe/notification/NotificationMonitorSpec.scala
+++ b/src/test/scala/thurloe/notification/NotificationMonitorSpec.scala
@@ -91,7 +91,9 @@ class NotificationMonitorSpec(_system: ActorSystem)
     awaitAssert(
       testNotifications
         .map(n => n.recipientUserEmail.value)
-        .toSet should contain theSameElementsAs (sendGridDAO.emails.asScala.map(email => email.getTos.head).toSet),
+        .toSet should contain theSameElementsAs (sendGridDAO.emails.asScala
+        .map(email => sendGridDAO.getTos(email).head)
+        .toSet),
       10 seconds
     )
 


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-235


What:

Upgrade `sendgrid-java` to latest 4.10.3. This jump has significant breaking changes, as the client library moves from using sendgrid v2 APIs to v3 APIs. This PR includes the necessary syntax changes to support the new library/APIs.

Tested by:
- [x] writing a one-off unit test that sends a real email, and verifying that the email looks the same before and after the upgrade
- [x] creating a BEE, turning on Thurloe email-sending in that BEE, and manually clicking around to generate emails
- [x] monitoring logs for my BEE's Thurloe to watch for error messages 
- [x] viewing the activity log in the SendGrid console and seeing the appropriate activity 

Reviewer: I could give you access to my running BEE if you want to test it out!

---

- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
