### PR TITLE
CORE-69: use setup-sbt, update other actions

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -23,6 +23,8 @@ jobs:
           java-version: 17
           cache: sbt
 
+      - uses: sbt/setup-sbt@v1
+
       - name: Check formatting for modified files
         run: |
           sbt scalafmtCheckAll

--- a/.github/workflows/merge_scalasteward_prs.yml
+++ b/.github/workflows/merge_scalasteward_prs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Merge scala-steward PRs
         id: msp
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
+          cache: sbt
+
+      - uses: sbt/setup-sbt@v1
 
       - name: Compile and check scalafmt
         env:
@@ -31,18 +35,9 @@ jobs:
         run: |
           export SBT_OPTS="-Duser.timezone=UTC -Denv.type=test"
           sbt coverage test coverageReport
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Setup Cache
-        uses: coursier/cache-action@v5
-      - name: Cache resources
-        run: |
-          rm -rf "$HOME/.ivy2/local" || true
-          find $HOME/Library/Caches/Coursier/v1        -name "ivydata-*.properties" -delete || true
-          find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true
-          find $HOME/.cache/coursier/v1                -name "ivydata-*.properties" -delete || true
-          find $HOME/.sbt                              -name "*.lock"               -delete || true

--- a/.github/workflows/thurloe-build-tag-publish.yml
+++ b/.github/workflows/thurloe-build-tag-publish.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
-      - uses: 'actions/checkout@v3'
+      - uses: 'actions/checkout@v4'
 
       - name: Bump the tag to a new version
         uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
@@ -53,7 +53,7 @@ jobs:
 
       # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
 
       - name: Explicitly auth Docker for Artifact Registry
         run: gcloud auth configure-docker $GOOGLE_DOCKER_REPOSITORY --quiet      

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -6,7 +6,7 @@ jobs:
     name: DSP AppSec Trivy check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # The Dockerfile copies this, so it needs to exist for the build to succeed 
       - run: touch thurloe.jar


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-69

What:
* add `setup-sbt` action where necessary, since ubuntu:latest no longer includes sbt
* update versions for a few other actions


---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
