### PR TITLE
CORE-266: remove GroupAccessRequestNotification entirely

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,9 @@ val slickV = "3.5.2"
 
 val scalaTestV = "3.2.19"
 
-val workbenchLibsHash = "4292239"
+val workbenchLibsHash = "a611e56"
 val workbenchGoogleV = s"0.34-$workbenchLibsHash"
-val workbenchNotificationsV = s"0.10-$workbenchLibsHash"
+val workbenchNotificationsV = s"1.0-$workbenchLibsHash"
 
 resolvers ++= Seq(
   "Broad Artifactory Releases" at "https://broadinstitute.jfrog.io/broadinstitute/libs-release/",

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -16,7 +16,6 @@ import thurloe.database.{DataAccess, KeyNotFoundException, ThurloeDatabaseConnec
 import thurloe.notification.NotificationMonitor.StartMonitorPass
 import thurloe.notification.NotificationMonitorSupervisor._
 
-import scala.annotation.nowarn
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -258,7 +257,6 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
   def groupManagementUrl(groupName: String): String = s"$fireCloudPortalUrl/#groups/${groupName}"
   def bucketUrl(bucketName: String): String = s"https://console.cloud.google.com/storage/browser/${bucketName}"
 
-  @nowarn("cat=deprecation")
   def toThurloeNotification(notification: Notification): thurloe.service.Notification = {
     val templateId = templateIdsByType(notification.getClass.getSimpleName)
 
@@ -425,20 +423,6 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
                                      Map("wsName" -> workspaceName.name, "wsUrl" -> workspacePortalUrl(workspaceName)),
                                      Map.empty,
                                      Map.empty
-        )
-
-      // GroupAccessRequestNotification is deprecated. Once Sam switches over to sending
-      // GroupAccessRequestNotificationV2, delete this case and the @nowarn annotation
-      // on the enclosing method.
-      case GroupAccessRequestNotification(recipientUserId, groupName, _, requesterId) =>
-        thurloe.service.Notification(
-          Option(recipientUserId),
-          None,
-          Option(requesterId),
-          templateId,
-          Map("groupName" -> groupName, "groupUrl" -> groupManagementUrl(groupName)),
-          Map("originEmail" -> requesterId),
-          Map("userNameFL" -> requesterId)
         )
 
       case GroupAccessRequestNotificationV2(recipientUserId, groupName, replyTo, requesterId) =>


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-266

Updates to workbench-libs notifications 1.0 and removes all references to `GroupAccessRequestNotification`, which was deprecated in notifications 0.10 and removed in notifications 1.0.

Context of the overall rollout plan to [adopt the SendGrid v3 APIs by February 10](https://www.twilio.com/docs/sendgrid/for-developers/sending-email/migrating-from-v2-to-v3-mail-send):

1. [DONE] https://github.com/broadinstitute/thurloe/pull/369, which ensures all email notifications use a single reply-to~
2. [DONE] https://github.com/broadinstitute/thurloe/pull/368, which adopts the latest `sendgrid-java` and v3 APIs
3. [DONE] Modify workbench-libs to deprecate the `GroupAccessRequestNotification` used by Sam which allows multiple reply-tos; provide a replacement `GroupAccessRequestNotificationV2` that only allows a single reply-to. See https://github.com/broadinstitute/workbench-libs/pull/1717 (this PR)
4. [DONE] Support the new `GroupAccessRequestNotificationV2` model in Thurloe. See https://github.com/broadinstitute/thurloe/pull/372
5. [DONE] https://github.com/broadinstitute/sam/pull/1627 Use the new `GroupAccessRequestNotificationV2` model in Sam. After this step, Thurloe would no longer ignore the reply-to value sent by Sam; Sam would once again be in control of the reply-to.
6. [DONE] Delete the deprecated `GroupAccessRequestNotification` from workbench-libs
7. [this PR] Remove support for the deprecated `GroupAccessRequestNotification` from Thurloe



---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
