### PR TITLE
TSPS-402 Update Teaspoons success notification to use userDataTtlDays param

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,9 @@ val slickV = "3.5.2"
 
 val scalaTestV = "3.2.19"
 
-val workbenchLibsHash = "a611e56"
+val workbenchLibsHash = "411cd3f"
 val workbenchGoogleV = s"0.34-$workbenchLibsHash"
-val workbenchNotificationsV = s"1.0-$workbenchLibsHash"
+val workbenchNotificationsV = s"1.1-$workbenchLibsHash"
 
 resolvers ++= Seq(
   "Broad Artifactory Releases" at "https://broadinstitute.jfrog.io/broadinstitute/libs-release/",

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -458,7 +458,8 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
                                              timeCompleted,
                                              quotaConsumedByJob,
                                              quotaRemaining,
-                                             userDescription
+                                             userDescription,
+      userDataTtlDays
           ) =>
         thurloe.service.Notification(
           Option(recipientUserId),
@@ -472,7 +473,8 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
             "timeCompleted" -> timeCompleted,
             "quotaConsumedByJob" -> quotaConsumedByJob,
             "quotaRemaining" -> quotaRemaining,
-            "userDescription" -> userDescription
+            "userDescription" -> userDescription,
+            "userDataTtlDays" -> userDataTtlDays
           ),
           Map.empty,
           Map.empty

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -459,7 +459,7 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
                                              quotaConsumedByJob,
                                              quotaRemaining,
                                              userDescription,
-      userDataTtlDays
+                                             userDataTtlDays
           ) =>
         thurloe.service.Notification(
           Option(recipientUserId),


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/TSPS-402

What:

This pr is following up changes made to workbench-libs in https://github.com/broadinstitute/workbench-libs/pull/1720 and https://github.com/broadinstitute/workbench-libs/pull/1721 that will grab a userDataTtlDays value from the notification message and use it to populate our notification.

Why:

We want to have this data available when creating our notification so we can inform our users how long they have before their inputs/outputs will be deleted

How:

We pull in the new workbench libs notifications library that was published in the PRs linked above and then pass in the new value to the teaspoons success notification.

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
