### PR TITLE
CORE-389: update azure-identity, which updates json-smart

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ libraryDependencies ++= Seq(
   "com.sendgrid" % "sendgrid-java" % "4.10.3",
   "ch.qos.logback" % "logback-classic" % "1.5.16",
   "org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-4cde1ff",
-  "com.azure" % "azure-identity" % "1.15.0",
+  "com.azure" % "azure-identity" % "1.15.4",
   "com.azure" % "azure-core-management" % "1.15.6",
 //---------- Test libraries -------------------//
   "org.broadinstitute.dsde.workbench" %%  "workbench-google" % workbenchGoogleV % Test classifier "tests",


### PR DESCRIPTION
Ticket: CORE-389

CORE-389 is a security finding on `json-smart`.

`json-smart` is pulled in by `com.azure:azure-identity`.

This PR updates `com.azure:azure-identity`, which in turn updates `json-smart`.

Part of a group of PRs:
* https://github.com/broadinstitute/rawls/pull/3240
* https://github.com/DataBiosphere/terra-resource-buffer/pull/422
* https://github.com/broadinstitute/thurloe/pull/377


