### PR TITLE
[CORE-419] Change Scala Steward Updates to Run Monthly

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -26,7 +26,7 @@
 #
 # Default: @asap
 #
-pullRequests.frequency = "0 3 ? * 3" # every thursday at 3am
+pullRequests.frequency = "0 0 1 * *" # first day of each month at midnight
 
 # pullRequests.customLabels allows to add custom labels to PRs.
 # This is useful if you want to use the labels for automation (project board for example).


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-419

Currently, Scala Steward updates run weekly, resulting in frequent PRs. To reduce PR overhead while still maintaining necessary security updates, this PR updates the schedule to run on the first day of each month.

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
