### PR TITLE
[CORE-419] Fix scala steward frequency config

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -26,7 +26,7 @@
 #
 # Default: @asap
 #
-pullRequests.frequency = "0 0 1 * *" # first day of each month at midnight
+pullRequests.frequency = "0 0 1 * ?" # first day of each month at midnight
 
 # pullRequests.customLabels allows to add custom labels to PRs.
 # This is useful if you want to use the labels for automation (project board for example).

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -26,7 +26,7 @@
 #
 # Default: @asap
 #
-pullRequests.frequency = "0 0 1 * *" # first day of each month at midnight
+pullRequests.frequency = "0 0 0 1 * ?" # first day of each month at midnight
 
 # pullRequests.customLabels allows to add custom labels to PRs.
 # This is useful if you want to use the labels for automation (project board for example).


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-419

Updated the Scala Steward cron schedule from `0 0 ? * MON` (every Monday at midnight) to `0 0 0 1 * ?` to run at midnight on the 1st of every month, reducing update frequency and aligning with a monthly maintenance cycle.

The cron expression follows the Quartz format, which is what [cron4s](https://github.com/alonsodomin/cron4s) (used by Scala Steward) supports. The updated expression, `0 0 0 1 * ?` means it runs at midnight on the 1st of every month. You can confirm it's valid in the [cron4s user guide](https://www.alonsodomin.me/cron4s/userguide/) or by testing it with any [Quartz cron expression tool](https://www.freeformatter.com/cron-expression-generator-quartz.html).

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
