### PR TITLE
DDO-4193 read from gar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,8 @@ val workbenchGoogleV = s"0.34-$workbenchLibsHash"
 val workbenchNotificationsV = s"1.1-$workbenchLibsHash"
 
 resolvers ++= Seq(
-  "Broad Artifactory Releases" at "https://broadinstitute.jfrog.io/broadinstitute/libs-release/",
-  "Broad Artifactory Snapshots" at "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/")
+  "Google Artifact Repository Releases" at "https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/",
+  "Google Artifact Repository Snapshots" at "https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/")
 
 libraryDependencies ++= Seq(
   "org.webjars" % "swagger-ui" % "5.18.2",


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DDO-4193

During brownout testing of artifact reads in JFrog Artifactory, we discovered there's a resolver that needs to be updated here.

This PR updates the resolver to point to Google Artifact Registry.

Publishing remains unchanged and continues to target JFrog.

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
