### PR TITLE
CORE-669: update to workbench-notifications 2.0 without Azure notifications

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,9 @@ val slickV = "3.5.2"
 
 val scalaTestV = "3.2.19"
 
-val workbenchLibsHash = "411cd3f"
-val workbenchGoogleV = s"0.34-$workbenchLibsHash"
-val workbenchNotificationsV = s"1.1-$workbenchLibsHash"
+val workbenchLibsHash = "56f2c74"
+val workbenchGoogleV = s"0.35-$workbenchLibsHash"
+val workbenchNotificationsV = s"2.0-$workbenchLibsHash"
 
 resolvers ++= Seq(
   "Google Artifact Repository Releases" at "https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/",

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -264,9 +264,6 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
       case ActivationNotification(recipentUserId) =>
         thurloe.service.Notification(Option(recipentUserId), None, None, templateId, Map.empty, Map.empty, Map.empty)
 
-      case AzurePreviewActivationNotification(recipentUserId) =>
-        thurloe.service.Notification(Option(recipentUserId), None, None, templateId, Map.empty, Map.empty, Map.empty)
-
       case WorkspaceAddedNotification(recipientUserId, accessLevel, workspaceName, workspaceOwnerId) =>
         thurloe.service.Notification(
           Option(recipientUserId),


### PR DESCRIPTION
[CORE-669](https://broadworkbench.atlassian.net/browse/CORE-669)

Updates to workbench-notifications 2.0, which removes the classes representing the Azure-only welcome email.

See also https://github.com/broadinstitute/workbench-libs/pull/1741

[CORE-669]: https://broadworkbench.atlassian.net/browse/CORE-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ