### PR TITLE
CORE-719: update azure-identity, which updates netty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ libraryDependencies ++= Seq(
   "com.sendgrid" % "sendgrid-java" % "4.10.3",
   "ch.qos.logback" % "logback-classic" % "1.5.16",
   "org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-4cde1ff",
-  "com.azure" % "azure-identity" % "1.15.4",
+  "com.azure" % "azure-identity" % "1.18.0",
   "com.azure" % "azure-core-management" % "1.15.6",
 //---------- Test libraries -------------------//
   "org.broadinstitute.dsde.workbench" %%  "workbench-google" % workbenchGoogleV % Test classifier "tests",


### PR DESCRIPTION
Jira: CORE-719

Upgrade `azure-identity`, which transitively requires netty. This upgrades netty to a more secure version.

### Before
<img width="553" height="604" alt="before" src="https://github.com/user-attachments/assets/09bee2ff-7593-456c-ae1d-72b68049e0b8" />

### After
<img width="529" height="533" alt="after" src="https://github.com/user-attachments/assets/b5df293d-5656-4328-9dda-e7ea84d0d160" />

