### PR TITLE
[CTM-305] Pin liquibase-core to 4.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -78,6 +78,9 @@ pullRequests.grouping = [ { name = "minor_patch", title = "CORE-69: Minor and pa
 # Each pattern must have `groupId`, `version` and optional `artifactId`.
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
 # the following example will allow to update foo when version is 1.1.x
+updates.pin  = [
+  { groupId = "org.liquibase", artifactId = "liquibase-core", version = "4." }
+]
 
 # The dependencies which match the given pattern are NOT updated.
 #


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-305

Pin liquibase-core to 4.x so that the upgrade to version 5 (which has a different software license) is no longer included in dependency update PRs.


---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
