### PR TITLE
[TSPS-748] Add new notification class for Teaspoons user quota change

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,9 @@ val slickV = "3.6.1"
 
 val scalaTestV = "3.2.19"
 
-val workbenchLibsHash = "56f2c74"
+val workbenchLibsHash = "38a12df"
 val workbenchGoogleV = s"0.35-$workbenchLibsHash"
-val workbenchNotificationsV = s"2.0-ea45f85c-SNAP"
+val workbenchNotificationsV = s"2.0-$workbenchLibsHash"
 
 resolvers ++= Seq(
   "Google Artifact Repository Releases" at "https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/",

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val scalaTestV = "3.2.19"
 
 val workbenchLibsHash = "56f2c74"
 val workbenchGoogleV = s"0.35-$workbenchLibsHash"
-val workbenchNotificationsV = s"2.0-$workbenchLibsHash"
+val workbenchNotificationsV = s"2.0-ea45f85c-SNAP"
 
 resolvers ++= Seq(
   "Google Artifact Repository Releases" at "https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/",

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -506,12 +506,14 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
           Map.empty
         )
 
-      case TeaspoonsUserQuotaChangedNotification(recipientUserId: WorkbenchUserId,
-      pipelineDisplayName: String,
-      previousQuotaLimit: String,
-      newQuotaLimit: String,
-      quotaConsumedByUser: String,
-      quotaAvailable: String) =>
+      case TeaspoonsUserQuotaChangedNotification(
+            recipientUserId: WorkbenchUserId,
+            pipelineDisplayName: String,
+            previousQuotaLimit: String,
+            newQuotaLimit: String,
+            quotaConsumedByUser: String,
+            quotaAvailable: String
+          ) =>
         thurloe.service.Notification(
           Option(recipientUserId),
           None,

--- a/src/main/scala/thurloe/notification/NotificationMonitor.scala
+++ b/src/main/scala/thurloe/notification/NotificationMonitor.scala
@@ -504,6 +504,28 @@ class NotificationMonitorActor(val pollInterval: FiniteDuration,
           ),
           Map.empty,
           Map.empty
+        )
+
+      case TeaspoonsUserQuotaChangedNotification(recipientUserId: WorkbenchUserId,
+      pipelineDisplayName: String,
+      previousQuotaLimit: String,
+      newQuotaLimit: String,
+      quotaConsumedByUser: String,
+      quotaAvailable: String) =>
+        thurloe.service.Notification(
+          Option(recipientUserId),
+          None,
+          None,
+          templateId,
+          Map(
+            "pipelineDisplayName" -> pipelineDisplayName,
+            "previousQuotaLimit" -> previousQuotaLimit,
+            "newQuotaLimit" -> newQuotaLimit,
+            "quotaConsumedByUser" -> quotaConsumedByUser,
+            "quotaAvailable" -> quotaAvailable
+          ),
+          Map.empty,
+          Map.empty
         );
     }
   }


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/TSPS-748

What:
This PR adds a new notification class to email users when their user quota for Imputation pipeline has been changed.

Why:
To send email to users when their quota for pipeline has been changed.

Related PRs:
- https://github.com/broadinstitute/workbench-libs/pull/1744
- https://github.com/broadinstitute/terra-helmfile/pull/6366
- https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/302

Tested end-to-end integration in a BEE. Screenshots:

Subject title:
<img width="680" height="96" alt="Screenshot 2026-01-30 at 3 49 32 PM" src="https://github.com/user-attachments/assets/23688f61-876b-42dc-91bd-2282f663fca5" />

Quota increase:
<img width="531" height="576" alt="Screenshot 2026-01-30 at 3 49 50 PM" src="https://github.com/user-attachments/assets/65b1884e-1efa-447d-991c-2be8d555cb2f" />

Quota decrease:
<img width="524" height="571" alt="Screenshot 2026-01-30 at 3 50 06 PM" src="https://github.com/user-attachments/assets/c65eb5ba-d7c2-47c2-a76e-5a0ef5854fee" />

---

- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
