### PR TITLE
CTM-573: bump sam-client and workbench-libs; exclude k8s client-java

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,9 @@ val slickV = "3.6.1"
 
 val scalaTestV = "3.2.19"
 
-val workbenchLibsHash = "38a12df"
-val workbenchGoogleV = s"0.35-$workbenchLibsHash"
-val workbenchNotificationsV = s"2.0-$workbenchLibsHash"
+val workbenchLibsHash = "2e5c77a"
+val workbenchGoogleV = s"0.36-$workbenchLibsHash"
+val workbenchNotificationsV = s"2.1-$workbenchLibsHash"
 
 resolvers ++= Seq(
   "Google Artifact Repository Releases" at "https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/",
@@ -35,7 +35,8 @@ libraryDependencies ++= Seq(
     exclude("org.bouncycastle", "bcprov-jdk15on")
     exclude("org.bouncycastle", "bcprov-ext-jdk15on")
     exclude("org.bouncycastle", "bcutil-jdk15on")
-    exclude("org.bouncycastle", "bcpkix-jdk15on"),
+    exclude("org.bouncycastle", "bcpkix-jdk15on")
+    exclude("io.kubernetes", "client-java"),
   "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % workbenchNotificationsV
     exclude("com.typesafe.akka", "akka-protobuf-v3_2.13")
     exclude("com.google.protobuf", "protobuf-java"),
@@ -54,7 +55,7 @@ libraryDependencies ++= Seq(
   "org.hsqldb" % "hsqldb" % "2.7.4",
   "com.sendgrid" % "sendgrid-java" % "4.10.3",
   "ch.qos.logback" % "logback-classic" % "1.5.27",
-  "org.broadinstitute.dsde.workbench" %% "sam-client" % "0.1-4cde1ff",
+  "org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.447",
 //---------- Test libraries -------------------//
   "org.broadinstitute.dsde.workbench" %%  "workbench-google" % workbenchGoogleV % Test classifier "tests",
   "com.typesafe.akka" %% "akka-testkit" % akkaV % Test,


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CTM-573

* Bumps to the latest versions of sam-client and workbench-libs to gain the benefits from:
    * https://github.com/broadinstitute/sam/pull/1754
    * https://github.com/broadinstitute/workbench-libs/pull/1751
    * https://github.com/broadinstitute/workbench-libs/pull/1752
* excludes `io.kubernetes:client-java` from workbench-libs google

## Before
```
❯ sbt dependencyTree | grep jackson-databind
[info]   | +-com.fasterxml.jackson.core:jackson-databind:2.14.0 (evicted by: 2.18.2)
[info]   | +-com.fasterxml.jackson.core:jackson-databind:2.18.2
[info]   | +-org.openapitools:jackson-databind-nullable:0.2.2
[info]   | | +-com.fasterxml.jackson.core:jackson-databind:2.12.2 (evicted by: 2.18.2)
[info]   | | +-com.fasterxml.jackson.core:jackson-databind:2.18.2
[info]   | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.17.2 (evicted by: ..
[info]   | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.18.2
[info]   | | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.17.2 (evicted by..
[info]   | | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.18.2
[info]   | | | |   +-com.fasterxml.jackson.core:jackson-databind:2.17.2 (evicted by: ..
[info]   | | | |   +-com.fasterxml.jackson.core:jackson-databind:2.18.2
[info]   | | | | +-com.fasterxml.jackson.core:jackson-databind:2.18.2
[info]   | | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.17.2 (evicted by..
[info]   | | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.18.2
[info]   | | | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.17.2 (evicted ..
[info]   | | | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.18.2
[info]   | | | | |   +-com.fasterxml.jackson.core:jackson-databind:2.17.2 (evicted by..
[info]   | | | | |   +-com.fasterxml.jackson.core:jackson-databind:2.18.2
[info]   | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.18.2
```

## After
```
❯ sbt dependencyTree | grep jackson-databind
[info]   | +-com.fasterxml.jackson.core:jackson-databind:2.14.0 (evicted by: 2.22.1)
[info]   | +-com.fasterxml.jackson.core:jackson-databind:2.22.1
[info]   | +-com.fasterxml.jackson.core:jackson-databind:2.22.1
[info]   | +-org.openapitools:jackson-databind-nullable:0.2.10
```