### PR TITLE
CTM-573: run on java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
 
 # Thurloe's HTTP Port
 EXPOSE 8000


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CTM-573

#406 updated the version of `sam-client` and `workbench-libs` used by Thurloe.

With those updates, Thurloe is failing to start with errors like:
```
Exception in thread "main" java.lang.UnsupportedClassVersionError: org/broadinstitute/dsde/workbench/client/sam/ApiClient has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```

Turns out, Thurloe was still running in live environments on Java 11. The newer Sam client was compiled with 17 and Thurloe can't use it.

This PR updates Thurloe to run on 17 instead.